### PR TITLE
feat(ci): add Claude CLI validation to plugin workflow

### DIFF
--- a/.github/actions/validate-plugin/action.yml
+++ b/.github/actions/validate-plugin/action.yml
@@ -1,5 +1,5 @@
 name: 'Validate Claudio Plugin'
-description: 'Validates plugin.json and all referenced paths using mise and Nushell'
+description: 'Validates plugin.json with Claude CLI and Nushell path validation'
 runs:
   using: 'composite'
   steps:
@@ -25,13 +25,16 @@ runs:
       shell: bash
       run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+    - name: Install Claude Code
+      shell: bash
+      run: npm install -g @anthropic-ai/claude-code
+
     - name: Install tools via mise
       shell: bash
       run: |
         mise trust
         mise install
 
-    - name: Run plugin validation
+    - name: Run all validations
       shell: bash
-      run: |
-        mise run test:plugin
+      run: mise run test

--- a/mise.toml
+++ b/mise.toml
@@ -3,13 +3,28 @@
 [tools]
 "ubi:nushell/nushell" = { version = "latest", exe = "nu" }
 
-[tasks."test:plugin"]
-description = "Validate plugin.json"
+[tasks.test]
+description = "Run all validation tests"
+depends = ["test:claude", "test:plugin"]
+
+[tasks."test:claude"]
+description = "Validate plugin with Claude CLI"
 run = """
 #!/usr/bin/env bash
 set -e
 
 cd "$(git rev-parse --show-toplevel)"
-echo "🔍 Validating claudio plugin..."
+echo "🔍 Validating with Claude CLI..."
+claude plugin validate .
+"""
+
+[tasks."test:plugin"]
+description = "Validate plugin paths with Nushell"
+run = """
+#!/usr/bin/env bash
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+echo "🔍 Validating plugin paths..."
 nu .github/scripts/validate-plugin.nu .claude-plugin/plugin.json --verbose
 """


### PR DESCRIPTION
- Add official `claude plugin validate .` CLI validation to CI workflow
  - Restructure mise tasks to run both validations in parallel