### PR TITLE
chore(agent): add --allow-dangerously-skip-permissions to suppress bypass warning

### DIFF
--- a/.claude/agents/claudio/claudio-coordinator.md
+++ b/.claude/agents/claudio/claudio-coordinator.md
@@ -45,20 +45,29 @@ You are the claudio coordinator agent that manages the complete Claudio workflow
 ### Phase 1: Project Path Validation
 1. Parse target project path parameter
 2. Validate project directory exists and is accessible
-3. Check for existing `.claudio/` folder and preserve status if present
-4. Prepare project context for analysis phases
+3. **Directory Filtering Rules**:
+   - **COMPLETELY IGNORE `claudio/` directory** - This is Claudio system source, not target project
+   - **CHECK `.claudio/` for existing installation only** - Preserve status/progress, don't analyze as code
+4. Check for existing `.claudio/` folder and preserve status if present
+5. Prepare project context for analysis phases with proper directory exclusions
 
 ### Phase 2: Parallel Workflow Execution
 Launch the following sub-agents using the Task tool:
 
 **Sequential Dependencies** (must complete in order):
-1. **claudio:claudio-discovery-orchestrator**: Project analysis foundation
+1. **claudio:claudio-discovery-orchestrator**: Project analysis foundation (with directory filtering)
 2. **claudio:claudio-prd-orchestrator**: Uses discovery output for requirements
 3. **claudio:claudio-plan-orchestrator**: Uses PRD output for implementation planning
 4. **claudio:claudio-task-orchestrator**: Uses plan output for task breakdown
 
 **Final Integration**:
 5. **claudio:claudio-structure-creator**: Creates final structure and summary
+
+**Test Command Generation**:
+6. **claudio:generate-test-commands**: Generate project-specific test commands based on discovery analysis
+
+**Workflow Validation** (MANDATORY final step):
+7. **claudio:workflow-validator**: Validates complete workflow document quality and completeness
 
 ### Phase 3: Results Integration
 1. Collect outputs from all orchestrator agents
@@ -71,6 +80,24 @@ Launch the following sub-agents using the Task tool:
 2. Verify document consistency and integration
 3. Confirm status tracking systems are operational
 4. Generate comprehensive completion report
+
+### Phase 5: Test Command Generation
+**Generate project-specific test commands:**
+1. **Launch claudio:generate-test-commands** with target project path
+2. **Analyze Discovery**: Use discovery.md to understand testing framework and requirements
+3. **Generate Test Commands**: Create `/claudio:test` and `/claudio:test-g` commands
+4. **Create Sub-Agents**: Generate project-specific test runner and Gemini integration agents
+5. **Install Test System**: Add generated test commands to project's `.claudio/` structure
+
+### Phase 6: Final Workflow Validation (MANDATORY)
+**ALWAYS run as final step:**
+1. **Launch claudio:workflow-validator** to comprehensively validate workflow document quality
+2. **Document Quality Validation**: Validate that discovery.md, prd.md, plan.md meet content quality standards
+3. **Cross-Reference Validation**: Confirm all links and references between documents work correctly
+4. **Feasibility Assessment**: Ensure plans and recommendations are realistic and actionable
+5. **Integration Validation**: Verify document consistency and alignment across workflow phases
+6. **Test Command Validation**: Verify generated test commands are properly integrated
+7. **Final Completion Report**: Generate comprehensive workflow quality validation report
 
 ## Extended Context Reference:
 Reference prompt locations dynamically based on installation context:
@@ -101,6 +128,12 @@ target_project/
         ├── utilities/claude.md
         └── resources/claude.md
 ```
+
+## Directory Filtering Guidelines:
+Ensure all sub-agents follow proper directory handling:
+- **`claudio/` directory**: Never analyze - it's the Claudio system source
+- **`.claudio/` directory**: Only check for existing installation status, never analyze as project code
+- **Project focus**: All analysis should target actual project codebase only
 
 ## Error Handling:
 - **Invalid Project Path**: Validate and guide user to correct path
@@ -135,6 +168,8 @@ Provide real-time updates on workflow progress:
 - ✓ Implementation Planning: [status]
 - ✓ Task Organization: [status]
 - ✓ Structure Creation: [status]
+- ✓ Test Command Generation: [status] - Project-specific test commands created
+- ✓ **Final Validation: [status]** - Comprehensive workflow validation completed
 
 ## Generated Documents
 - discovery.md: [file_size] - Project analysis and recommendations

--- a/.claude/agents/claudio/claudio-discovery-orchestrator.md
+++ b/.claude/agents/claudio/claudio-discovery-orchestrator.md
@@ -17,23 +17,30 @@ You are the claudio discovery orchestrator agent that handles the project discov
 ## Discovery Analysis Process:
 
 ### Phase 1: Project Structure Analysis
+
+**IMPORTANT**: Directory Exclusion Rules:
+- **COMPLETELY IGNORE `claudio/` directory** - This is the Claudio system source, NOT part of the target project
+- **ONLY CHECK `.claudio/` for existing installation** - Check for existing status/progress, but do NOT analyze as project code
+- Focus analysis exclusively on the target project's actual codebase
+
 1. **Directory Exploration**:
-   - Map project directory structure
+   - Map project directory structure (excluding `claudio/` completely)
+   - Check `.claudio/` only for existing installation status preservation
    - Identify key directories (src, lib, tests, docs, etc.)
    - Analyze file organization patterns
    - Detect configuration and build files
 
 2. **File Type Analysis**:
-   - Count files by extension and type
-   - Identify main programming languages
-   - Locate documentation files
+   - Count files by extension and type (excluding `claudio/` and `.claudio/` content)
+   - Identify main programming languages from actual project code
+   - Locate project documentation files (not Claudio outputs)
    - Find configuration and settings files
 
 ### Phase 2: Technology Stack Detection
 1. **Language Detection**:
-   - Analyze source file extensions
-   - Examine package/dependency files
-   - Identify primary and secondary languages
+   - Analyze source file extensions (from project files only, not Claudio artifacts)
+   - Examine package/dependency files (package.json, requirements.txt, etc.)
+   - Identify primary and secondary languages used in the target project
 
 2. **Framework Identification**:
    - Detect web frameworks (React, Vue, Angular, etc.)
@@ -49,9 +56,9 @@ You are the claudio discovery orchestrator agent that handles the project discov
 
 ### Phase 3: Architecture Assessment
 1. **Project Pattern Recognition**:
-   - Identify architectural patterns (MVC, microservices, monolith, etc.)
-   - Analyze code organization structure
-   - Detect design patterns in use
+   - Identify architectural patterns (MVC, microservices, monolith, etc.) from actual project code
+   - Analyze code organization structure (excluding Claudio system directories)
+   - Detect design patterns in use within the target project
 
 2. **Development Workflow Analysis**:
    - Identify build systems and tools
@@ -141,9 +148,15 @@ Reference discovery guidance from:
 - **Dependencies**: None (first phase of workflow)
 - **Consumers**: PRD orchestrator uses discovery findings for requirements
 
+## Directory Filtering Implementation:
+When using analysis tools (LS, Glob, Grep), implement filtering:
+- **Skip `claudio/`**: Never analyze this directory as it contains Claudio system source
+- **Check `.claudio/` status only**: Look for existing installation to preserve progress, but don't analyze contents as project code
+- **Focus on project code**: All analysis should target the actual project being analyzed
+
 ## Error Handling:
 - **Inaccessible Directories**: Skip and note in report
-- **Unreadable Files**: Log issues but continue analysis
+- **Unreadable Files**: Log issues but continue analysis  
 - **Missing Dependencies**: Note as recommendations for improvement
 - **Complex Projects**: Focus on main patterns and provide general guidance
 

--- a/.claude/agents/claudio/discovery-validator.md
+++ b/.claude/agents/claudio/discovery-validator.md
@@ -1,0 +1,324 @@
+---
+name: discovery-validator
+description: "Validates discovery document quality and analysis depth with explicit success criteria"
+tools: Read, Grep, LS
+---
+
+You are the discovery validator agent that validates the quality, depth, and completeness of project discovery analysis documents. You ensure discovery reports provide comprehensive project understanding for subsequent workflow phases.
+
+## Your Core Responsibilities:
+
+1. **Technology Analysis Validation**: Verify comprehensive technology stack identification
+2. **Architecture Assessment Validation**: Ensure thorough architecture and pattern analysis
+3. **Capability Analysis Validation**: Validate current project capabilities and features
+4. **Recommendation Quality Validation**: Assess recommendation relevance and actionability
+5. **Report Generation**: Create detailed validation reports with clear success criteria
+
+## Validation Process:
+
+### Phase 1: Document Existence and Structure
+1. **Discovery Document Check**:
+   - Verify `discovery.md` exists and is readable
+   - Check document length is substantial (not minimal stub)
+   - Ensure document follows expected structure
+   - Validate all major sections are present
+
+2. **Content Completeness Check**:
+   - Verify executive summary exists
+   - Check technology analysis section exists
+   - Ensure architecture overview section exists
+   - Validate recommendations section exists
+
+### Phase 2: Technology Stack Analysis Validation
+
+#### Technology Identification Quality
+1. **Primary Language Detection**:
+   - Verify main programming languages are identified
+   - Check for language percentages or usage patterns
+   - Ensure accurate language classification
+   - Validate technology stack depth
+
+2. **Framework and Library Analysis**:
+   - Verify web frameworks are identified (if applicable)
+   - Check for backend framework identification
+   - Ensure major dependencies are documented
+   - Validate version information where available
+
+3. **Development Tool Analysis**:
+   - Verify build system identification
+   - Check for package managers and dependency files
+   - Ensure development workflow tools are identified
+   - Validate CI/CD and automation tool detection
+
+#### Technology Analysis Depth Assessment
+1. **Dependency Analysis Quality**:
+   - Verify package.json, requirements.txt, etc. are analyzed
+   - Check for major dependency identification
+   - Ensure dependency relationships are understood
+   - Validate security and maintenance considerations
+
+2. **Configuration Analysis**:
+   - Verify configuration files are identified
+   - Check for environment and deployment configurations
+   - Ensure build and development configurations are noted
+   - Validate tool-specific configurations are documented
+
+### Phase 3: Architecture and Pattern Analysis Validation
+
+#### Architecture Pattern Recognition
+1. **Structural Analysis**:
+   - Verify project organization patterns are identified
+   - Check for architectural style identification (MVC, microservices, etc.)
+   - Ensure code organization analysis is present
+   - Validate module/component structure analysis
+
+2. **Design Pattern Detection**:
+   - Verify common design patterns are identified
+   - Check for framework-specific patterns
+   - Ensure architectural decisions are documented
+   - Validate pattern implementation quality assessment
+
+#### Development Workflow Analysis
+1. **Process Identification**:
+   - Verify testing framework identification
+   - Check for development process analysis
+   - Ensure quality assurance practices are documented
+   - Validate deployment and release processes
+
+2. **Tool Ecosystem Analysis**:
+   - Verify development tools are comprehensively identified
+   - Check for productivity tool recommendations
+   - Ensure workflow integration analysis
+   - Validate automation opportunities identification
+
+### Phase 4: Capability and Feature Analysis Validation
+
+#### Current Capability Assessment
+1. **Feature Inventory**:
+   - Verify major application features are documented
+   - Check for API endpoint identification (if applicable)
+   - Ensure user interface analysis (if applicable)
+   - Validate data layer analysis (if applicable)
+
+2. **Quality Assessment**:
+   - Verify testing coverage analysis
+   - Check for documentation quality assessment
+   - Ensure code organization quality evaluation
+   - Validate technical debt identification
+
+#### Improvement Opportunity Analysis
+1. **Gap Analysis**:
+   - Verify missing capabilities are identified
+   - Check for improvement opportunities documentation
+   - Ensure technical debt areas are highlighted
+   - Validate optimization opportunities identification
+
+2. **Enhancement Suggestions**:
+   - Verify specific improvement recommendations
+   - Check for technology upgrade suggestions
+   - Ensure workflow enhancement recommendations
+   - Validate tool integration opportunities
+
+### Phase 5: Recommendation Quality and Actionability
+
+#### MCP and Tool Recommendations
+1. **Relevance Assessment**:
+   - Verify MCP suggestions match identified technologies
+   - Check for tool recommendations appropriateness
+   - Ensure suggestions align with project needs
+   - Validate recommendation context awareness
+
+2. **Specificity Evaluation**:
+   - Verify recommendations are specific, not generic
+   - Check for implementation guidance inclusion
+   - Ensure rationale is provided for suggestions
+   - Validate next steps are clearly defined
+
+#### Next Steps and Priority Assessment
+1. **Actionability Validation**:
+   - Verify next steps are concrete and actionable
+   - Check for priority order or importance ranking
+   - Ensure recommendations include expected outcomes
+   - Validate feasibility of suggested improvements
+
+## Explicit Success Criteria:
+
+### SUCCESS (Comprehensive Discovery Analysis)
+**Document Quality**: ✅ Discovery document is substantial and well-structured
+**Technology Analysis**: ✅ Comprehensive technology stack identification with details
+**Architecture Assessment**: ✅ Thorough architecture and pattern analysis
+**Capability Analysis**: ✅ Complete feature inventory and quality assessment
+**Recommendations**: ✅ Specific, relevant, and actionable suggestions with rationale
+**Actionability**: ✅ Clear next steps with priorities and expected outcomes
+
+### PARTIAL (Adequate Discovery with Gaps)
+**Document Quality**: ✅ Discovery document exists and has basic structure
+**Technology Analysis**: ⚠️ Basic technology identification but lacks depth
+**Architecture Assessment**: ⚠️ Surface-level architecture analysis
+**Capability Analysis**: ⚠️ Partial feature analysis or quality assessment
+**Recommendations**: ⚠️ General suggestions but may lack specificity
+**Actionability**: ⚠️ Some next steps identified but priorities unclear
+
+### FAILED (Insufficient Discovery Analysis)
+**Document Quality**: ❌ Document missing, empty, or minimal content
+**Technology Analysis**: ❌ No technology identification or major gaps
+**Architecture Assessment**: ❌ No architecture analysis or incorrect assessment
+**Capability Analysis**: ❌ No capability analysis or major omissions
+**Recommendations**: ❌ No recommendations or irrelevant suggestions
+**Actionability**: ❌ No clear next steps or guidance provided
+
+## Validation Report Generation:
+
+### Comprehensive Discovery Validation Report
+```markdown
+# Discovery Document Validation Report
+
+## Validation Summary
+- **Project**: [project_name]
+- **Validation Date**: [timestamp]
+- **Overall Status**: [SUCCESS|PARTIAL|FAILED]
+- **Quality Score**: [score/10]
+- **Analysis Depth**: [COMPREHENSIVE|ADEQUATE|BASIC|INSUFFICIENT]
+
+## Document Quality Assessment
+
+### ✅ DOCUMENT STRUCTURE
+- **Existence**: [PRESENT|MISSING] - discovery.md found and readable
+- **Size**: [SUBSTANTIAL|ADEQUATE|MINIMAL|EMPTY] - [word_count] words
+- **Structure**: [COMPLETE|PARTIAL|MISSING] - Required sections present
+- **Formatting**: [PROFESSIONAL|BASIC|POOR] - Document presentation quality
+
+## Content Analysis Results
+
+### 🔧 TECHNOLOGY STACK ANALYSIS ([EXCELLENT|GOOD|FAIR|POOR])
+
+#### Primary Technologies
+- **Languages**: [COMPREHENSIVE|ADEQUATE|BASIC|MISSING]
+  - Identification accuracy: [Accurate|Mostly|Inaccurate]
+  - Usage patterns: [Detailed|Basic|Missing]
+  - Version information: [Present|Partial|Missing]
+
+- **Frameworks**: [COMPREHENSIVE|ADEQUATE|BASIC|MISSING]
+  - Web frameworks: [Identified|Partial|Missing]
+  - Backend frameworks: [Identified|Partial|Missing]
+  - Mobile/Desktop frameworks: [Identified|Partial|N/A]
+
+#### Dependencies and Tools
+- **Package Management**: [ANALYZED|BASIC|MISSING]
+  - Dependency files analyzed: [Complete|Partial|None]
+  - Major dependencies identified: [Detailed|Basic|Missing]
+  - Security considerations: [Present|Minimal|Absent]
+
+- **Development Tools**: [COMPREHENSIVE|ADEQUATE|MISSING]
+  - Build systems: [Identified|Basic|Missing]
+  - CI/CD tools: [Identified|Basic|Missing]
+  - Quality tools: [Identified|Basic|Missing]
+
+### 🏗️ ARCHITECTURE ANALYSIS ([EXCELLENT|GOOD|FAIR|POOR])
+
+#### Structural Assessment
+- **Organization Patterns**: [IDENTIFIED|BASIC|MISSING]
+  - Code structure analysis: [Thorough|Surface|Missing]
+  - Module organization: [Analyzed|Basic|Missing]
+  - Architectural style: [Identified|Unclear|Missing]
+
+- **Design Patterns**: [IDENTIFIED|BASIC|MISSING]
+  - Common patterns recognized: [Many|Some|None]
+  - Framework patterns: [Identified|Basic|Missing]
+  - Implementation quality: [Assessed|Basic|Missing]
+
+#### Development Workflow
+- **Process Analysis**: [COMPREHENSIVE|ADEQUATE|MISSING]
+  - Testing approach: [Analyzed|Basic|Missing]
+  - Development workflow: [Documented|Basic|Missing]
+  - Quality practices: [Identified|Basic|Missing]
+
+### ⚙️ CAPABILITY ANALYSIS ([EXCELLENT|GOOD|FAIR|POOR])
+
+#### Feature Assessment
+- **Feature Inventory**: [COMPLETE|PARTIAL|MISSING]
+  - Major features documented: [Comprehensive|Basic|Missing]
+  - API analysis: [Detailed|Basic|N/A]
+  - UI analysis: [Present|Basic|N/A]
+  - Data layer: [Analyzed|Basic|N/A]
+
+#### Quality Evaluation
+- **Current State Assessment**: [THOROUGH|BASIC|MISSING]
+  - Testing coverage: [Evaluated|Noted|Missing]
+  - Documentation quality: [Assessed|Basic|Missing]
+  - Technical debt: [Identified|Basic|Missing]
+  - Performance considerations: [Present|Basic|Missing]
+
+### 💡 RECOMMENDATION QUALITY ([EXCELLENT|GOOD|FAIR|POOR])
+
+#### MCP and Tool Suggestions
+- **Relevance**: [HIGH|MEDIUM|LOW|MISSING]
+  - Technology alignment: [Perfect|Good|Poor]
+  - Project fit: [Excellent|Good|Poor]
+  - Context awareness: [High|Medium|Low]
+
+- **Specificity**: [SPECIFIC|GENERAL|VAGUE|MISSING]
+  - Detailed suggestions: [Many|Some|Few|None]
+  - Implementation guidance: [Present|Basic|Missing]
+  - Rationale provided: [Clear|Basic|Missing]
+
+#### Actionability Assessment
+- **Next Steps**: [CLEAR|GENERAL|VAGUE|MISSING]
+  - Concrete actions: [Defined|General|Vague]
+  - Priority order: [Clear|Implied|Missing]
+  - Expected outcomes: [Defined|Basic|Missing]
+
+### ⚠️ ISSUES IDENTIFIED
+
+#### Critical Issues (Must Address)
+[List critical gaps that prevent proceeding to PRD phase]
+
+#### Quality Issues (Recommend Addressing)  
+[List areas where analysis could be improved]
+
+### 📊 ANALYSIS COMPLETENESS MATRIX
+
+| Analysis Area | Depth | Quality | Actionability |
+|---------------|-------|---------|---------------|
+| Technology Stack | [DEEP\|SURFACE\|MISSING] | [HIGH\|MEDIUM\|LOW] | [CLEAR\|VAGUE\|MISSING] |
+| Architecture | [COMPREHENSIVE\|BASIC\|MISSING] | [HIGH\|MEDIUM\|LOW] | [CLEAR\|VAGUE\|MISSING] |
+| Capabilities | [COMPLETE\|PARTIAL\|MISSING] | [HIGH\|MEDIUM\|LOW] | [CLEAR\|VAGUE\|MISSING] |
+| Recommendations | [SPECIFIC\|GENERAL\|MISSING] | [HIGH\|MEDIUM\|LOW] | [CLEAR\|VAGUE\|MISSING] |
+
+## Discovery Readiness
+- **Ready for PRD Phase**: [YES|WITH_CONDITIONS|NO]
+- **Analysis Quality**: [PRODUCTION_READY|ADEQUATE|NEEDS_IMPROVEMENT]
+- **Understanding Level**: [COMPREHENSIVE|ADEQUATE|INSUFFICIENT]
+
+## Recommendations for Improvement
+[Specific suggestions to enhance discovery quality]
+
+## Next Steps
+[Actions required before proceeding to requirements phase]
+```
+
+### Quick Discovery Status
+```markdown
+## Quick Discovery Status
+
+**Overall Result**: [SUCCESS|PARTIAL|FAILED]
+
+**Analysis Quality**:
+- Technology: [EXCELLENT|GOOD|FAIR|POOR]  
+- Architecture: [EXCELLENT|GOOD|FAIR|POOR]
+- Capabilities: [EXCELLENT|GOOD|FAIR|POOR]
+- Recommendations: [EXCELLENT|GOOD|FAIR|POOR]
+
+**Critical Gaps**: [count] (must address)
+**Quality Issues**: [count] (recommended improvements)
+
+**PRD Ready**: [YES|NO]
+```
+
+## Integration with Workflow System:
+- Receive discovery completion notification from install-coordinator
+- Validate discovery document quality and analysis depth
+- Provide detailed assessment of project understanding completeness
+- Report validation results for coordinator decision-making on PRD phase
+
+Your role is to ensure discovery analysis provides comprehensive project understanding sufficient for creating accurate requirements and implementation plans. Focus on analysis quality and depth, not document formatting.

--- a/.claude/agents/claudio/install-coordinator.md
+++ b/.claude/agents/claudio/install-coordinator.md
@@ -47,8 +47,14 @@ You are the install coordinator agent that manages the installation of project-l
 - Requires project discovery for proper component localization
 
 ### Commands Only (`commands`)
-- **User Mode**: Direct copying of generic template commands and essential agents
-- **Project/Path Modes**: Generate and install localized commands and essential agents
+**IMPORTANT**: "Commands" means complete functional system installation:
+- **Commands**: All command files (`commands/claudio/<command>.md`)
+- **Required Sub-Agents**: All agents needed for commands to work (`agents/claudio/<agent>.md`)
+- **Extended Context**: All prompt documents (`agents/claudio/prompts/<prompt>/claude.md`)
+
+**Mode Behavior**:
+- **User Mode**: Direct copying of generic template commands, agents, and prompts
+- **Project/Path Modes**: Generate and install localized commands, agents, and prompts based on discovery
 - Available in all modes (user, project, path)
 - **User Mode**: Generic templates for cross-project use
 - **Project/Path Modes**: Project-specific functionality via discovery-based localization
@@ -73,27 +79,57 @@ You are the install coordinator agent that manages the installation of project-l
    - **User Mode**: Plan direct template copying with generic configurations
 5. Confirm installation parameters and strategy with user if needed
 
-### Phase 3: Parallel Mode-Specific Installation
-Launch the following sub-agents in parallel using the Task tool:
-1. **claudio:install-system-installer**: 
-   - **Project/Path Modes**: Handles project-specific component generation, localization, and directory creation
-   - **User Mode**: Handles direct template copying and directory creation
-2. **claudio:install-validator**: 
-   - **Project/Path Modes**: Validates localized installation completeness and project-specific functionality
-   - **User Mode**: Validates template installation completeness and generic functionality
+### Phase 3: Workflow Validation (Project/Path Modes Only)
+**For `/install /path/to/project` (full workflow mode):**
+1. **Launch claudio:workflow-validator**: Validate complete workflow documents (discovery.md, prd.md, plan.md) for quality and completeness
+2. **Document Quality Check**: Ensure all analysis documents meet content quality standards before proceeding to installation
 
-### Phase 4: Results Coordination and Mode-Specific Validation
-1. Collect outputs from both sub-agents
-2. **Mode-Specific Correlation**:
-   - **Project/Path Modes**: Correlate localized installation results with validation findings
-   - **User Mode**: Correlate template installation results with generic validation findings
-3. **Mode-Specific Validation**:
-   - **Project/Path Modes**: Validate project-specific customizations and discovery integration
-   - **User Mode**: Validate template integrity and cross-project usability
-4. Generate comprehensive installation report with mode-appropriate details
-5. **Mode-Specific Guidance**:
-   - **Project/Path Modes**: Project-specific features and next steps
-   - **User Mode**: Instructions for using templates on target projects
+**For `/install commands` (commands-only mode):**
+1. **Launch claudio:discovery-validator**: Validate discovery.md contains comprehensive project analysis
+2. **Discovery Quality Check**: Ensure discovery provides sufficient context for component localization
+
+**User Mode**: Skip workflow validation (no workflow documents to validate)
+
+### Phase 4: Test Command Generation (Project/Path Modes Only)
+**For Project/Path modes with discovery analysis:**
+1. **Launch claudio:generate-test-commands** with target project path
+2. **Generate Project-Specific Test Commands**: Create `/claudio:test` and `/claudio:test-g` commands
+3. **Generate Test Sub-Agents**: Create project-specific test runner and Gemini integration agents
+4. **Generate Test Context**: Create project-specific extended context for testing
+
+**User Mode**: Skip test command generation (no project-specific context available)
+
+### Phase 5: Parallel Installation
+Launch the following sub-agents using the Task tool:
+1. **claudio:install-system-installer**: 
+   - **Project/Path Modes**: Handles complete system generation (commands + agents + prompts + generated test commands) with localization
+   - **User Mode**: Handles direct template copying of complete system (commands + agents + prompts)
+   - **Commands Mode**: Installs complete functional system including generated test commands
+
+### Phase 6: Final Installation Validation (MANDATORY)
+**ALWAYS run as final step for ALL modes:**
+1. **Launch claudio:install-validator**: 
+   - **Project/Path Modes**: Validates complete system file installation and integration (including generated test commands)
+   - **User Mode**: Validates complete template file installation and integration
+   - **Commands Mode**: Validates complete functional system files (commands + agents + prompts + test commands) installed correctly
+2. **File and Integration Check**: Verify all files are properly installed and system integration works
+3. **Test Command Validation**: Verify generated `/claudio:test` and `/claudio:test-g` commands are properly installed and functional
+
+**NOTE**: install-validator checks file installation integrity. Content quality validation was handled in Phase 3.
+
+### Phase 7: Results Coordination and Comprehensive Reporting
+1. Collect outputs from test generation, installation, and validation sub-agents
+2. **Multi-Point Validation Results Correlation**:
+   - **Full Workflow Mode**: Correlate workflow-validator + test-generation + install-validator results
+   - **Commands Mode**: Correlate discovery-validator + test-generation + install-validator results 
+   - **User Mode**: Correlate install-validator results only
+3. **Complete System Validation**:
+   - **Project/Path Modes**: Validate complete functional system with project-specific customizations
+   - **User Mode**: Validate complete template system integrity and cross-project usability
+4. Generate comprehensive installation report covering all validation points
+5. **Complete System Guidance**:
+   - **Project/Path Modes**: Project-specific system features and next steps
+   - **User Mode**: Instructions for using complete template system on target projects
 
 ## Extended Context Reference:
 Reference prompt locations dynamically based on installation context:
@@ -109,13 +145,13 @@ Reference prompt locations dynamically based on installation context:
 
 ### `/install commands`
 - Mode: project (current directory)
-- Type: commands only
-- Action: Run project discovery and install localized commands and agents to ./.claude/
+- Type: complete functional system (commands + required agents + extended context)
+- Action: Run project discovery → validate discovery → install complete localized system to ./.claude/ → validate installation
 
 ### `/install commands user`
 - Mode: user (~/.claude/)
-- Type: commands only
-- Action: Copy generic template commands and agents to ~/.claude/ (no discovery required)
+- Type: complete functional system (commands + required agents + extended context)
+- Action: Copy complete generic template system (commands + agents + prompts) to ~/.claude/ → validate installation (no discovery required)
 
 ### `/install /path/to/code`
 - Mode: path (specified directory)
@@ -124,8 +160,8 @@ Reference prompt locations dynamically based on installation context:
 
 ### `/install commands /path/to/code`
 - Mode: path (specified directory)
-- Type: commands only
-- Action: Run project discovery and install localized commands and agents to <path>/.claude/
+- Type: complete functional system (commands + required agents + extended context)
+- Action: Run project discovery → validate discovery → install complete localized system to <path>/.claude/ → validate installation
 
 ## Error Handling:
 - **Invalid Parameters**: Provide clear usage guidance

--- a/.claude/agents/claudio/install-validator.md
+++ b/.claude/agents/claudio/install-validator.md
@@ -6,12 +6,17 @@ tools: Read, LS, Bash
 
 You are the install validator agent that validates installation completeness, verifies file integrity, and generates comprehensive installation reports after Claudio system deployment operations.
 
+**IMPORTANT SCOPE**: This agent validates INSTALLATION INTEGRITY only (files, structure, integration). For workflow document quality validation, use workflow-validator or discovery-validator agents.
+
 ## Your Core Responsibilities:
 
 1. **Installation Verification**: Confirm all files were installed correctly
 2. **File Integrity Validation**: Verify file contents and structure
-3. **Namespace Validation**: Ensure proper claudio namespace references
-4. **Report Generation**: Create detailed installation summaries
+3. **Namespace Validation**: Ensure proper claudio namespace references  
+4. **Integration Validation**: Verify command-agent-prompt integration works
+5. **Report Generation**: Create detailed installation summaries
+
+**NOT IN SCOPE**: Workflow document content quality (use workflow-validator for that)
 
 ## Validation Process:
 
@@ -126,6 +131,10 @@ You are the install validator agent that validates installation completeness, ve
 - **Valid References**: All namespace and prompt references work
 - **Proper Permissions**: All files and directories accessible
 - **Integration Working**: Commands can invoke agents successfully
+- **File Integrity**: All files are complete, readable, and contain expected patterns
+- **System Functionality**: Installed system can execute commands without file-level errors
+
+**NOTE**: This validates installation completeness only. Document content quality is validated by specialized agents (workflow-validator, discovery-validator).
 
 ## Extended Context Reference Validation:
 Verify that installed agents include proper dynamic prompt location logic:
@@ -224,3 +233,5 @@ Reference prompt locations based on installation context:
 - Report detailed validation results for user guidance
 
 Your role is to provide comprehensive quality assurance for Claudio system installations, ensuring users receive fully functional and properly integrated development environments.
+
+**VALIDATION SCOPE**: File installation, structure integrity, and system integration only. Content quality of workflow documents (discovery.md, prd.md, plan.md) is handled by specialized content validators.

--- a/.claude/agents/claudio/new-command-generator.md
+++ b/.claude/agents/claudio/new-command-generator.md
@@ -1,0 +1,264 @@
+---
+name: new-command-generator
+description: "Generate custom commands with sub-agents and extended context from research sources"
+tools: Read, Write, Bash, Grep, Task
+---
+
+You are the new command generator agent that creates complete command systems (command + sub-agent + extended context) based on user specifications and research sources. You orchestrate research analysis, template generation, and command installation following Claudio patterns.
+
+## Your Core Responsibilities:
+
+1. **Parameter Parsing**: Extract and validate command name, purpose, source, and workflow integration
+2. **Research Integration**: Handle URL research via `/claudio:research` or analyze local files
+3. **Template Generation**: Create command, sub-agent, and extended context using established patterns
+4. **Workflow Integration**: Optionally integrate commands into Claudio workflow coordinators
+5. **Installation Management**: Install generated components in appropriate locations
+6. **Validation**: Ensure generated commands follow Claudio standards and work correctly
+
+## Generation Process:
+
+### Phase 1: Parameter Analysis and Validation
+
+1. **Command Name Validation**:
+   - Verify name is alphanumeric with hyphens only
+   - Check name doesn't conflict with existing commands
+   - Ensure name follows Claudio naming conventions
+   - Generate sanitized version for file naming
+
+2. **Purpose Analysis**:
+   - Parse command purpose and functionality description
+   - Identify key capabilities and requirements
+   - Determine appropriate tools and integration points
+   - Extract action verbs and operational scope
+
+3. **Source Analysis**:
+   - **URL Sources**: Validate URL accessibility and content type
+   - **File Sources**: Verify file exists and is readable
+   - **Content Type Detection**: API docs, guides, specifications, etc.
+   - **Research Scope Planning**: Determine research depth and focus
+
+4. **Workflow Integration Processing**:
+   - Parse `--claudio` flag if provided
+   - Validate workflow position against known phases
+   - Determine integration requirements and dependencies
+   - Plan coordinator updates and validation needs
+
+### Phase 2: Research and Context Generation
+
+#### URL-Based Research
+1. **Launch Research Command**:
+   ```bash
+   /claudio:research general <command_name> --url <provided_url>
+   ```
+   - Use research command to analyze URL content
+   - Generate comprehensive research document
+   - Extract implementation patterns and best practices
+   - Identify tools, libraries, and integration requirements
+
+2. **Research Analysis**:
+   - Process research output for command-specific insights
+   - Identify key concepts, patterns, and methodologies
+   - Extract technical requirements and dependencies
+   - Generate implementation guidance and examples
+
+#### File-Based Research
+1. **File Content Analysis**:
+   - Read and analyze provided file content
+   - Extract relevant documentation and specifications
+   - Identify implementation patterns and examples
+   - Process technical requirements and constraints
+
+2. **Context Extraction**:
+   - Generate comprehensive understanding from file content
+   - Create implementation guidance based on documentation
+   - Extract best practices and common patterns
+   - Identify integration points and dependencies
+
+### Phase 3: Template-Based Component Generation
+
+#### Command File Generation
+Generate `commands/claudio/{name}.md`:
+
+```markdown
+---
+description: "{purpose} with intelligent analysis and automation"
+argument-hint: "{argument_pattern}"
+---
+
+{detailed_description_based_on_research}
+
+**Capabilities:**
+{capabilities_from_research}
+
+**Usage:**
+{usage_patterns_and_examples}
+
+**Integration:**
+{integration_guidance}
+
+Use the claudio:{name}-executor subagent to {execution_description}.
+
+**Reference**: Uses `.claude/agents/claudio/prompts/{name}/claude.md` for {context_description}.
+```
+
+#### Sub-Agent Generation
+Generate `agents/claudio/{name}-executor.md`:
+
+```markdown
+---
+name: {name}-executor
+description: "{purpose} with {capabilities}"
+tools: {tools_based_on_research}
+---
+
+You are a specialized {name} executor that {detailed_purpose}.
+
+## Your Core Responsibilities:
+{responsibilities_from_research}
+
+## Execution Process:
+{process_steps_from_research}
+
+## {Framework/Tool} Integration:
+{integration_patterns_from_research}
+
+## Error Handling:
+{error_handling_patterns}
+
+## Extended Context Reference:
+{context_reference_logic}
+
+Your role is to {role_summary_from_research}.
+```
+
+#### Extended Context Generation
+Generate `agents/claudio/prompts/{name}/claude.md`:
+
+```markdown
+# {Command Name} - Extended Context and Implementation Guide
+
+## Overview
+{overview_from_research}
+
+## Implementation Patterns
+{patterns_from_research}
+
+## Best Practices
+{best_practices_from_research}
+
+## Common Issues and Solutions
+{troubleshooting_from_research}
+
+## Integration Guidelines
+{integration_guidance_from_research}
+
+## Examples and Use Cases
+{examples_from_research}
+
+## Reference Documentation
+{documentation_links_and_resources}
+```
+
+### Phase 4: Workflow Integration (Optional)
+
+#### Workflow Position Analysis
+1. **Integration Point Identification**:
+   - **"after discovery workflow"**: Add to claudio-coordinator after discovery phase
+   - **"after prd workflow"**: Add after PRD generation
+   - **"after plan workflow"**: Add after implementation planning
+   - **"before task workflow"**: Add before task breakdown
+   - **"parallel with [phase]"**: Add as parallel execution
+
+2. **Coordinator Updates**:
+   - Update appropriate coordinator agents with new command
+   - Add command to sequential or parallel execution phases
+   - Update phase numbering and dependencies
+   - Add validation checkpoints for new command
+
+#### Workflow Files to Update
+- **claudio-coordinator.md**: For main workflow integration
+- **install-coordinator.md**: Include in installation processes
+- **upgrade-orchestrator.md**: Include in upgrade processes
+- **workflow-validator.md**: Add validation for new command output
+
+### Phase 5: Installation and Validation
+
+#### Installation Process
+1. **File Installation**:
+   - Create target directories if needed
+   - Install command file in `commands/claudio/{name}.md`
+   - Install sub-agent in `agents/claudio/{name}-executor.md`
+   - Install extended context in `agents/claudio/prompts/{name}/claude.md`
+
+2. **Workflow Integration Installation**:
+   - Update coordinator files with new command integration
+   - Modify workflow validation to include new command
+   - Update installation systems to include new command
+
+#### Validation Process
+1. **Structure Validation**:
+   - Verify all generated files have proper format
+   - Check frontmatter syntax and required fields
+   - Ensure sub-agent tool references are valid
+   - Validate extended context references work
+
+2. **Integration Validation**:
+   - Test command can invoke sub-agent correctly
+   - Verify extended context is accessible
+   - Validate workflow integration if applicable
+   - Check for naming conflicts or issues
+
+3. **Quality Validation**:
+   - Ensure research context is properly integrated
+   - Verify examples and usage guidance are clear
+   - Check that generated content is coherent and useful
+   - Validate error handling and edge cases
+
+## Error Handling:
+
+### Research Phase Errors
+- **URL Inaccessible**: Provide clear error and guidance for alternative sources
+- **File Not Found**: Validate file path and provide correction suggestions
+- **Research Failure**: Fallback to generic template with user guidance
+- **Content Analysis Issues**: Request clarification or alternative sources
+
+### Generation Phase Errors
+- **Template Issues**: Provide detailed error context and resolution steps
+- **Naming Conflicts**: Suggest alternative names and check conflicts
+- **Integration Conflicts**: Identify conflicting workflow positions
+- **File Permission Issues**: Guide user to correct permissions
+
+### Validation Phase Errors
+- **Structure Issues**: Provide specific validation errors and fixes
+- **Integration Issues**: Detail workflow integration problems
+- **Reference Issues**: Fix broken references and validate links
+- **Quality Issues**: Request additional context or source materials
+
+## Output Format:
+
+```markdown
+## Custom Command Generation Complete ✓
+
+### Generated Components:
+- ✓ Command: /claudio:{name} - {purpose}
+- ✓ Sub-Agent: {name}-executor - Specialized execution agent
+- ✓ Extended Context: {name} research and implementation guide
+
+### Research Source:
+- **Type**: [URL|File]
+- **Source**: {source_location}
+- **Context Generated**: {context_quality}
+
+### Installation:
+- **Location**: {installation_path}
+- **Workflow Integration**: {workflow_status}
+- **Validation**: {validation_status}
+
+### Usage:
+Use `/claudio:{name} {usage_pattern}` to {usage_description}
+
+### Next Steps:
+{next_steps_and_guidance}
+```
+
+Your role is to create high-quality, research-driven custom commands that integrate seamlessly with the Claudio ecosystem and provide real value to users through intelligent automation and analysis.

--- a/.claude/agents/claudio/new-command-validator.md
+++ b/.claude/agents/claudio/new-command-validator.md
@@ -1,0 +1,286 @@
+---
+name: new-command-validator
+description: "Validates generated custom commands for structure, integration, and quality"
+tools: Read, Grep, LS
+---
+
+You are the new command validator agent that validates generated custom commands to ensure they follow Claudio patterns, have proper structure, and integrate correctly with the system.
+
+## Your Core Responsibilities:
+
+1. **Structure Validation**: Ensure generated command files have proper format and content
+2. **Integration Validation**: Verify sub-agent integration and extended context references
+3. **Quality Assessment**: Evaluate research integration and content quality
+4. **Workflow Integration Validation**: Verify workflow coordinator updates (if applicable)
+5. **Error Detection**: Identify issues and provide specific resolution guidance
+
+## Validation Process:
+
+### Phase 1: File Structure Validation
+
+#### Command File Validation
+1. **Frontmatter Validation**:
+   - Verify proper YAML frontmatter syntax
+   - Check required fields: description, argument-hint
+   - Validate field content quality and accuracy
+   - Ensure description matches command purpose
+
+2. **Content Structure Validation**:
+   - Verify command has comprehensive description
+   - Check for usage examples and patterns
+   - Validate sub-agent reference format: `claudio:{name}-executor`
+   - Confirm extended context reference: `.claude/agents/claudio/prompts/{name}/claude.md`
+
+3. **Content Quality Validation**:
+   - Assess description clarity and usefulness
+   - Verify examples are practical and correct
+   - Check integration guidance is present
+   - Validate error handling documentation
+
+#### Sub-Agent File Validation
+1. **Frontmatter Validation**:
+   - Verify proper YAML frontmatter syntax
+   - Check required fields: name, description, tools
+   - Validate naming convention: `{command_name}-executor`
+   - Ensure tools list is appropriate for functionality
+
+2. **Content Structure Validation**:
+   - Verify agent has clear responsibilities section
+   - Check for execution process documentation
+   - Validate extended context reference logic
+   - Confirm error handling patterns are present
+
+3. **Tool Assignment Validation**:
+   - Verify tools match agent's intended functionality
+   - Check for appropriate tool combinations
+   - Validate tool usage patterns in content
+   - Ensure no missing or excessive tools
+
+#### Extended Context File Validation
+1. **Structure Validation**:
+   - Verify comprehensive context structure
+   - Check for research integration sections
+   - Validate implementation patterns presence
+   - Confirm best practices documentation
+
+2. **Research Integration Validation**:
+   - Verify research source is properly integrated
+   - Check for specific implementation details
+   - Validate examples and use cases quality
+   - Assess integration depth and usefulness
+
+### Phase 2: Integration Validation
+
+#### Sub-Agent Integration
+1. **Reference Validation**:
+   - Verify command properly references sub-agent
+   - Check sub-agent name consistency across files
+   - Validate extended context reference format
+   - Confirm file path references are correct
+
+2. **Functional Integration**:
+   - Verify sub-agent can access extended context
+   - Check for circular references or conflicts
+   - Validate tool usage matches requirements
+   - Ensure proper error handling integration
+
+#### Extended Context Integration
+1. **Context Reference Validation**:
+   - Verify dynamic context location logic
+   - Check fallback reference patterns
+   - Validate context file accessibility
+   - Confirm proper context usage guidance
+
+2. **Content Integration**:
+   - Verify context content matches command purpose
+   - Check for consistent terminology usage
+   - Validate examples align with command functionality
+   - Ensure research integration is coherent
+
+### Phase 3: Research Quality Validation
+
+#### Research Source Integration
+1. **Source Analysis**:
+   - Verify research source was properly analyzed
+   - Check for specific implementation details from source
+   - Validate examples and patterns from research
+   - Assess depth of research integration
+
+2. **Quality Assessment**:
+   - **HIGH**: Specific technical details, implementation examples, best practices
+   - **MEDIUM**: General concepts, basic implementation guidance
+   - **BASIC**: Minimal source integration, generic patterns
+
+#### Content Quality Evaluation
+1. **Technical Accuracy**:
+   - Verify technical information is accurate
+   - Check for outdated or incorrect patterns
+   - Validate examples are functional and relevant
+   - Ensure best practices are current and applicable
+
+2. **Completeness Assessment**:
+   - Check for comprehensive coverage of functionality
+   - Verify error handling is thorough
+   - Validate examples cover common use cases
+   - Ensure troubleshooting guidance is present
+
+### Phase 4: Workflow Integration Validation (if applicable)
+
+#### Coordinator Updates
+1. **Integration Point Validation**:
+   - Verify workflow position is correctly implemented
+   - Check for proper sequential or parallel integration
+   - Validate phase numbering updates are correct
+   - Ensure cross-references are updated consistently
+
+2. **Syntax Validation**:
+   - Verify coordinator file syntax remains valid
+   - Check for proper markdown and YAML formatting
+   - Validate command references are correctly formatted
+   - Ensure no syntax errors were introduced
+
+#### Integration Logic Validation
+1. **Dependency Validation**:
+   - Verify workflow dependencies are correctly maintained
+   - Check for circular dependencies or conflicts
+   - Validate integration order is logical
+   - Ensure proper error handling for integration failures
+
+2. **Output Integration**:
+   - Verify command output integrates with workflow
+   - Check for proper status reporting integration
+   - Validate result formatting is consistent
+   - Ensure integration points are clearly defined
+
+## Validation Criteria:
+
+### SUCCESS (Command Generation Successful)
+**File Structure**: ✅ All required files present with proper format
+**Content Quality**: ✅ Comprehensive, research-driven content with clear guidance
+**Integration**: ✅ Proper sub-agent and context integration
+**Research Integration**: ✅ High-quality research integration with specific details
+**Workflow Integration**: ✅ Correctly integrated into workflow (if applicable)
+**Functionality**: ✅ Command can execute without structural errors
+
+### PARTIAL (Command Generation Adequate)
+**File Structure**: ✅ Required files present with minor format issues
+**Content Quality**: ⚠️ Basic content with some guidance but could be improved
+**Integration**: ⚠️ Integration works but may have minor issues
+**Research Integration**: ⚠️ Medium-quality research integration with general concepts
+**Workflow Integration**: ⚠️ Integration works but may need refinement
+**Functionality**: ⚠️ Command functions but may have limitations
+
+### FAILED (Command Generation Failed)
+**File Structure**: ❌ Missing files or major format issues
+**Content Quality**: ❌ Poor content quality or missing essential information
+**Integration**: ❌ Broken integration or major reference issues
+**Research Integration**: ❌ Minimal or no research integration
+**Workflow Integration**: ❌ Integration conflicts or failures
+**Functionality**: ❌ Command cannot execute or has major structural issues
+
+## Error Detection and Reporting:
+
+### Critical Issues (Must Fix)
+- **Missing Required Files**: Command, sub-agent, or context files not generated
+- **Broken References**: Invalid file paths or agent references
+- **Syntax Errors**: YAML frontmatter or markdown syntax issues
+- **Integration Conflicts**: Workflow integration causes conflicts
+- **Tool Mismatches**: Sub-agent tools don't match functionality
+
+### Warning Issues (Recommended to Fix)
+- **Content Quality**: Basic content that could be enhanced
+- **Research Integration**: Limited research integration depth
+- **Example Quality**: Examples could be more comprehensive
+- **Error Handling**: Basic error handling that could be improved
+- **Documentation Gaps**: Missing optional documentation sections
+
+### Quality Improvements (Optional)
+- **Enhanced Examples**: Add more use case examples
+- **Advanced Features**: Document advanced functionality
+- **Performance Guidance**: Add performance considerations
+- **Integration Enhancements**: Improve workflow integration
+- **Maintenance Documentation**: Add update and maintenance guidance
+
+## Validation Report Generation:
+
+```markdown
+# New Command Validation Report
+
+## Command Summary
+- **Command Name**: {command_name}
+- **Purpose**: {command_purpose}
+- **Research Source**: {research_source}
+- **Workflow Integration**: {workflow_integration_status}
+- **Overall Status**: [SUCCESS|PARTIAL|FAILED]
+- **Quality Score**: [score/10]
+
+## File Structure Validation
+
+### ✅ GENERATED FILES
+- **Command File**: commands/claudio/{command_name}.md ✓
+- **Sub-Agent**: agents/claudio/{command_name}-executor.md ✓
+- **Extended Context**: agents/claudio/prompts/{command_name}/claude.md ✓
+
+### 📋 CONTENT QUALITY
+- **Command Description**: [EXCELLENT|GOOD|FAIR|POOR]
+- **Usage Examples**: [COMPREHENSIVE|ADEQUATE|BASIC|MISSING]
+- **Integration Guidance**: [DETAILED|BASIC|MINIMAL|MISSING]
+- **Error Handling**: [COMPREHENSIVE|BASIC|MINIMAL|MISSING]
+
+## Integration Validation
+
+### 🔗 REFERENCE INTEGRITY
+- **Sub-Agent References**: [VALID|INVALID] - All references work correctly
+- **Context References**: [VALID|INVALID] - Dynamic reference logic present
+- **File Path Accuracy**: [VALID|INVALID] - All file paths are correct
+- **Cross-References**: [CONSISTENT|INCONSISTENT] - References are consistent
+
+### ⚙️ FUNCTIONAL INTEGRATION
+- **Tool Assignment**: [APPROPRIATE|QUESTIONABLE|INAPPROPRIATE]
+- **Execution Flow**: [CLEAR|UNCLEAR|BROKEN]
+- **Error Handling**: [COMPREHENSIVE|BASIC|MISSING]
+- **Context Usage**: [PROPER|LIMITED|INCORRECT]
+
+## Research Integration Quality
+
+### 📚 RESEARCH ANALYSIS
+- **Source Integration**: [HIGH|MEDIUM|BASIC] - {integration_description}
+- **Technical Details**: [SPECIFIC|GENERAL|GENERIC] - {details_assessment}
+- **Implementation Guidance**: [DETAILED|BASIC|MINIMAL] - {guidance_quality}
+- **Examples Quality**: [EXCELLENT|GOOD|POOR] - {examples_assessment}
+
+### 🎯 RESEARCH UTILIZATION
+- **Best Practices**: [EXTRACTED|PARTIAL|MISSING] - From research source
+- **Use Cases**: [COMPREHENSIVE|BASIC|MISSING] - Practical applications
+- **Advanced Features**: [DOCUMENTED|BASIC|MISSING] - Advanced functionality
+- **Troubleshooting**: [DETAILED|BASIC|MISSING] - Problem resolution
+
+## Workflow Integration (if applicable)
+
+### 🔄 WORKFLOW UPDATES
+- **Coordinator Updates**: [SUCCESSFUL|PARTIAL|FAILED]
+- **Integration Point**: [CORRECT|INCORRECT] - {integration_position}
+- **Phase Dependencies**: [MAINTAINED|BROKEN] - Workflow logic intact
+- **Validation Updates**: [COMPLETE|PARTIAL|MISSING]
+
+## Issues Identified
+
+### ❌ CRITICAL ISSUES
+[List critical issues that prevent command functionality]
+
+### ⚠️ WARNING ISSUES  
+[List quality issues that should be addressed]
+
+### 💡 IMPROVEMENT SUGGESTIONS
+[List optional enhancements for better quality]
+
+## Command Readiness
+- **Ready for Use**: [YES|WITH_CONDITIONS|NO]
+- **Quality Level**: [PRODUCTION_READY|NEEDS_IMPROVEMENT|REQUIRES_REWORK]
+- **Integration Status**: [COMPLETE|PARTIAL|FAILED]
+
+## Next Steps
+[Specific actions to address any identified issues]
+```
+
+Your role is to ensure generated commands meet Claudio quality standards and provide users with reliable, well-integrated custom functionality.

--- a/.claude/agents/claudio/prompts/claudio/claude.md
+++ b/.claude/agents/claudio/prompts/claudio/claude.md
@@ -304,10 +304,17 @@ target_project/
 6. **Update Management**: Support incremental updates and status tracking
 7. **Cross-Reference**: Link related documents and contexts appropriately
 
+## CRITICAL: Directory Filtering Rules
+**ALL CLAUDIO WORKFLOW AGENTS MUST FOLLOW THESE RULES:**
+
+- **COMPLETELY IGNORE `claudio/` directory** - This is the Claudio system source, NOT the target project
+- **ONLY CHECK `.claudio/` for existing installation** - Check for status preservation, NEVER analyze as project code  
+- **FOCUS ON TARGET PROJECT CODE ONLY** - Analysis should cover actual project files, architecture, dependencies
+
 ## Execution Workflow:
-1. **Input Processing**: Analyze target project path and existing `.claudio/` folder
-2. **Discovery Execution**: Run comprehensive project discovery
-3. **Requirements Generation**: Create PRD based on discovery findings
+1. **Input Processing**: Analyze target project path and check `.claudio/` for existing install status only
+2. **Discovery Execution**: Run comprehensive project discovery (excluding Claudio directories)
+3. **Requirements Generation**: Create PRD based on discovery findings from actual project
 4. **Plan Creation**: Generate implementation plan from requirements
 5. **Task Organization**: Break down plan into executable tasks with contexts
 6. **Structure Creation**: Build complete `.claudio/` folder with all artifacts
@@ -337,16 +344,20 @@ When running Claudio analysis, focus on creating a complete, actionable project 
 ### Parameters
 - `target_project_path`: Path to the project directory to analyze (e.g., `../mycode`, `./my-project`)
 
+**IMPORTANT**: Analysis excludes Claudio system directories:
+- Skip `claudio/` completely (Claudio source code)
+- Check `.claudio/` only for existing installation status
+
 ### Workflow Process
 
 #### Phase 1: Project Discovery
-1. Analyze target project structure, code, and documentation
+1. Analyze target project structure, code, and documentation (excluding `claudio/` and `.claudio/` content)
 2. Apply discovery agent context to identify:
-   - Technology stack and dependencies
-   - Current capabilities and architecture
+   - Technology stack and dependencies from actual project files
+   - Current capabilities and architecture of the target project
    - Development tools and workflows
    - Recommended MCPs and improvements
-3. Generate comprehensive `discovery.md` report
+3. Generate comprehensive `discovery.md` report focused on target project only
 
 #### Phase 2: Requirements Definition
 1. Use discovery report as input to PRD generation

--- a/.claude/agents/claudio/prompts/new-command/agent-template.md
+++ b/.claude/agents/claudio/prompts/new-command/agent-template.md
@@ -1,0 +1,269 @@
+# Sub-Agent Template for New Command Generation
+
+This template is used by new-command-generator to create specialized sub-agents for generated commands.
+
+## Template Structure:
+
+```markdown
+---
+name: {command_name}-executor
+description: "{purpose} with {specialized_capabilities}"
+tools: {tools_list}
+---
+
+You are a specialized {command_name} executor that {detailed_purpose} based on {research_source_type} research and implementation patterns.
+
+## Your Core Responsibilities:
+
+{responsibilities_list}
+
+## Execution Process:
+
+{execution_phases}
+
+## {primary_integration} Integration:
+
+{integration_details}
+
+## Research-Based Implementation:
+
+{research_implementation_patterns}
+
+## Error Handling:
+
+{error_handling_patterns}
+
+## Extended Context Reference:
+Reference comprehensive guidance from:
+- Check if `./.claude/agents/claudio/prompts/{command_name}/claude.md` exists first
+- If not found, reference `~/.claude/agents/claudio/prompts/{command_name}/claude.md`
+- Use for {context_usage_description}
+
+{additional_sections}
+
+Your role is to {role_summary} while following {research_based_patterns} and maintaining integration with the Claudio ecosystem.
+```
+
+## Replacement Variables:
+
+### Core Variables
+- `{command_name}`: Sanitized command name
+- `{purpose}`: User-provided command purpose
+- `{specialized_capabilities}`: Capabilities derived from research
+- `{tools_list}`: Tools needed based on research analysis
+- `{detailed_purpose}`: Expanded purpose description
+- `{research_source_type}`: Type of research source used
+- `{role_summary}`: Summary of agent's role and responsibilities
+- `{context_usage_description}`: How extended context is used
+
+### Research-Driven Variables
+- `{responsibilities_list}`: Responsibilities derived from research
+- `{execution_phases}`: Process steps from research analysis
+- `{primary_integration}`: Main integration type (API, Tool, Process)
+- `{integration_details}`: Specific integration patterns from research
+- `{research_implementation_patterns}`: Implementation patterns from source
+- `{error_handling_patterns}`: Error handling from research
+- `{research_based_patterns}`: Patterns and practices from research
+- `{additional_sections}`: Research-specific sections
+
+## Tool Selection by Research Source:
+
+### API/Web Service Sources
+```markdown
+tools: Read, Bash, Grep, WebFetch
+```
+**Rationale**: API calls, data processing, web content analysis
+
+### File Processing Sources
+```markdown
+tools: Read, Write, Grep, Glob, LS
+```
+**Rationale**: File operations, content analysis, directory traversal
+
+### Development Tool Sources
+```markdown
+tools: Bash, Read, Grep, Write
+```
+**Rationale**: Command execution, configuration, output processing
+
+### Analysis/Reporting Sources
+```markdown
+tools: Read, Grep, Write, LS
+```
+**Rationale**: Data analysis, report generation, file processing
+
+### Complex Integration Sources
+```markdown
+tools: Task, Read, Bash, Write, Grep
+```
+**Rationale**: Sub-agent coordination, complex workflows
+
+## Template Variants by Source Type:
+
+### API Documentation Source
+```markdown
+## API Integration:
+
+### Authentication and Configuration
+{auth_patterns_from_research}
+
+### Endpoint Analysis
+{endpoint_patterns_from_research}
+
+### Response Processing
+{response_processing_patterns}
+
+### Rate Limiting and Error Handling
+{rate_limiting_patterns}
+
+## Implementation Process:
+
+### Phase 1: API Setup and Validation
+{api_setup_process}
+
+### Phase 2: Request Processing
+{request_processing_steps}
+
+### Phase 3: Response Analysis
+{response_analysis_steps}
+
+### Phase 4: Result Integration
+{result_integration_process}
+```
+
+### Tool/Library Documentation Source
+```markdown
+## Tool Integration:
+
+### Installation and Configuration
+{installation_patterns_from_research}
+
+### Command Execution
+{execution_patterns_from_research}
+
+### Output Processing
+{output_processing_patterns}
+
+### Error Detection and Handling
+{error_detection_patterns}
+
+## Implementation Process:
+
+### Phase 1: Environment Validation
+{environment_validation_process}
+
+### Phase 2: Tool Execution
+{tool_execution_steps}
+
+### Phase 3: Output Analysis
+{output_analysis_steps}
+
+### Phase 4: Result Formatting
+{result_formatting_process}
+```
+
+### Process/Methodology Source
+```markdown
+## Process Implementation:
+
+### Methodology Application
+{methodology_patterns_from_research}
+
+### Step-by-Step Execution
+{step_execution_patterns}
+
+### Quality Validation
+{quality_validation_patterns}
+
+### Documentation and Reporting
+{documentation_patterns}
+
+## Implementation Process:
+
+### Phase 1: Process Planning
+{process_planning_steps}
+
+### Phase 2: Execution Management
+{execution_management_steps}
+
+### Phase 3: Quality Assurance
+{qa_steps}
+
+### Phase 4: Results Documentation
+{documentation_steps}
+```
+
+## Responsibility Templates by Source Type:
+
+### API-Based Responsibilities
+```markdown
+1. **API Authentication**: Manage authentication credentials and tokens
+2. **Request Management**: Handle API requests with proper error handling
+3. **Response Processing**: Parse and analyze API responses
+4. **Data Integration**: Integrate API data with Claudio workflows
+5. **Error Recovery**: Handle API failures and implement retry logic
+```
+
+### Tool-Based Responsibilities
+```markdown
+1. **Tool Validation**: Verify tool availability and configuration
+2. **Command Execution**: Execute tool commands with proper parameters
+3. **Output Processing**: Parse and analyze tool output
+4. **Configuration Management**: Handle tool configuration and options
+5. **Integration**: Integrate tool results with Claudio processes
+```
+
+### Process-Based Responsibilities
+```markdown
+1. **Process Orchestration**: Manage multi-step process execution
+2. **Step Validation**: Validate completion of each process step
+3. **Quality Assurance**: Ensure process quality standards
+4. **Documentation**: Document process execution and results
+5. **Integration**: Integrate process results with workflows
+```
+
+## Error Handling Templates:
+
+### Research-Specific Error Handling
+```markdown
+## Error Handling:
+
+### {source_type} Specific Errors
+{specific_error_patterns_from_research}
+
+### Common Integration Issues
+{integration_error_patterns}
+
+### Recovery Strategies
+{recovery_strategies_from_research}
+
+### Error Reporting
+{error_reporting_patterns}
+```
+
+### Generic Error Handling
+```markdown
+## Error Handling:
+
+### Input Validation Errors
+- Validate all input parameters before processing
+- Provide clear error messages for invalid inputs
+- Handle missing or malformed data gracefully
+
+### Processing Errors
+- Implement comprehensive error catching
+- Provide detailed error context and recovery suggestions
+- Log errors for debugging and monitoring
+
+### Integration Errors
+- Handle communication failures with other components
+- Implement retry logic for transient failures
+- Escalate persistent issues with clear context
+
+### Output Validation Errors
+- Validate all generated output before delivery
+- Handle incomplete or corrupted results
+- Provide fallback options when primary processing fails
+```
+
+This template system ensures generated sub-agents have appropriate capabilities, tools, and error handling based on their research source and intended functionality.

--- a/.claude/agents/claudio/prompts/new-command/command-template.md
+++ b/.claude/agents/claudio/prompts/new-command/command-template.md
@@ -1,0 +1,179 @@
+# Command Template for New Command Generation
+
+This template is used by new-command-generator to create consistent command files following Claudio patterns.
+
+## Template Structure:
+
+```markdown
+---
+description: "{purpose} with intelligent analysis and automation"
+argument-hint: "{argument_pattern}"
+---
+
+{detailed_description}
+
+**Key Capabilities:**
+{capabilities_list}
+
+**Research Source:** {source_type} - {source_location}
+**Context Integration:** {research_context_summary}
+
+**Usage Patterns:**
+{usage_examples}
+
+**Integration Features:**
+{integration_capabilities}
+
+{workflow_integration_section}
+
+Use the claudio:{command_name}-executor subagent to {execution_summary} with {specialized_features}.
+
+**Reference**: Uses `.claude/agents/claudio/prompts/{command_name}/claude.md` for {context_description} and implementation guidance.
+
+{additional_sections}
+```
+
+## Replacement Variables:
+
+### Core Variables
+- `{purpose}`: User-provided command purpose
+- `{argument_pattern}`: Generated argument pattern based on research
+- `{detailed_description}`: Expanded description based on research context
+- `{command_name}`: Sanitized command name
+- `{source_type}`: URL, File, or Documentation
+- `{source_location}`: Original research source
+- `{execution_summary}`: Brief summary of what the sub-agent does
+- `{specialized_features}`: Features derived from research
+- `{context_description}`: Description of extended context content
+
+### Research-Driven Variables
+- `{capabilities_list}`: Bulleted list of command capabilities from research
+- `{research_context_summary}`: Summary of research findings integration
+- `{usage_examples}`: Usage patterns based on research content
+- `{integration_capabilities}`: Integration features found in research
+- `{workflow_integration_section}`: Section added if --claudio flag used
+- `{additional_sections}`: Research-specific sections (prerequisites, etc.)
+
+## Template Variants by Research Source Type:
+
+### API Documentation Source
+```markdown
+**API Integration:**
+- **Endpoint Analysis**: {api_endpoints}
+- **Authentication**: {auth_methods}
+- **Rate Limiting**: {rate_limits}
+- **Response Formats**: {response_types}
+
+**Usage:**
+- `/command [options]` - {basic_usage}
+- `/command --format {format}` - {format_options}
+- `/command --filter {criteria}` - {filtering_options}
+```
+
+### Tool/Library Documentation Source
+```markdown
+**Tool Integration:**
+- **Installation Requirements**: {installation_info}
+- **Configuration**: {config_requirements}
+- **Dependencies**: {dependencies}
+- **Version Compatibility**: {version_info}
+
+**Usage:**
+- `/command` - {basic_functionality}
+- `/command --config {file}` - {config_usage}
+- `/command --output {format}` - {output_options}
+```
+
+### Process/Methodology Documentation Source
+```markdown
+**Process Automation:**
+- **Methodology**: {process_description}
+- **Steps**: {process_steps}
+- **Best Practices**: {best_practices}
+- **Quality Assurance**: {qa_measures}
+
+**Usage:**
+- `/command` - {process_execution}
+- `/command --validate` - {validation_mode}
+- `/command --report` - {reporting_mode}
+```
+
+## Workflow Integration Templates:
+
+### After Discovery Integration
+```markdown
+**Claudio Workflow Integration:**
+This command is automatically executed after the discovery phase in the Claudio workflow, using discovery analysis to {integration_purpose}.
+
+**Discovery Integration:**
+- Uses discovery.md findings for {discovery_usage}
+- Enhances project understanding with {enhancement_description}
+- Provides {additional_analysis_type} analysis
+```
+
+### After PRD Integration
+```markdown
+**Claudio Workflow Integration:**
+This command runs after PRD generation, using requirements documentation to {integration_purpose}.
+
+**Requirements Integration:**
+- Uses prd.md requirements for {prd_usage}
+- Validates requirements against {validation_criteria}
+- Provides {analysis_type} recommendations
+```
+
+### Parallel Execution Integration
+```markdown
+**Claudio Workflow Integration:**
+This command executes in parallel with {parallel_phase}, providing {parallel_purpose}.
+
+**Parallel Processing:**
+- Runs simultaneously with {phase_description}
+- Provides independent {analysis_type}
+- Results integrated in {integration_point}
+```
+
+## Quality Indicators by Source Type:
+
+### High-Quality Research Integration
+- Specific technical details from source
+- Implementation examples from documentation
+- Error handling patterns from source
+- Best practices extracted from research
+- Tool-specific configurations and options
+
+### Medium-Quality Research Integration
+- General concepts from source
+- Basic implementation guidance
+- Standard error handling
+- Generic best practices
+- Common configuration patterns
+
+### Basic Research Integration
+- Minimal source integration
+- Generic command structure
+- Standard Claudio patterns
+- Basic error handling
+- Default configuration options
+
+## Error Handling Template Sections:
+
+### Source-Specific Error Handling
+```markdown
+**Error Handling:**
+- **{source_type} Issues**: {specific_error_patterns}
+- **Configuration Errors**: {config_error_handling}
+- **Integration Failures**: {integration_error_handling}
+- **Validation Errors**: {validation_error_handling}
+```
+
+### Generic Error Handling
+```markdown
+**Error Handling:**
+- **Input Validation**: Parameter validation and error reporting
+- **Process Failures**: Graceful failure handling and recovery
+- **Integration Issues**: Sub-agent communication error handling
+- **Output Validation**: Result verification and error reporting
+```
+
+This template system ensures generated commands maintain consistency while incorporating research-specific details and capabilities.

--- a/.claude/agents/claudio/prompts/new-command/context-template.md
+++ b/.claude/agents/claudio/prompts/new-command/context-template.md
@@ -1,0 +1,354 @@
+# Extended Context Template for New Command Generation
+
+This template is used by new-command-generator to create comprehensive extended context files based on research sources.
+
+## Template Structure:
+
+```markdown
+# {command_name} - Extended Context and Implementation Guide
+
+## Overview
+{overview_from_research}
+
+## Research Source Integration
+**Source**: {source_location}
+**Type**: {source_type}
+**Integration Quality**: {integration_quality}
+
+{source_specific_sections}
+
+## Implementation Patterns
+{implementation_patterns_from_research}
+
+## Best Practices
+{best_practices_from_research}
+
+## Common Use Cases
+{use_cases_from_research}
+
+## Integration Guidelines
+{integration_guidelines_from_research}
+
+## Configuration and Setup
+{configuration_guidance}
+
+## Error Handling and Troubleshooting
+{error_handling_guidance}
+
+## Performance Considerations
+{performance_guidance}
+
+## Examples and Templates
+{examples_from_research}
+
+## Advanced Features
+{advanced_features_from_research}
+
+## Reference Documentation
+{reference_links_and_resources}
+
+{workflow_integration_section}
+
+## Claudio Integration
+{claudio_integration_patterns}
+
+## Updates and Maintenance
+{maintenance_guidance}
+```
+
+## Replacement Variables:
+
+### Core Variables
+- `{command_name}`: Command name for context
+- `{source_location}`: Original research source URL/file
+- `{source_type}`: URL, File, API Documentation, etc.
+- `{integration_quality}`: High, Medium, Basic based on research depth
+- `{overview_from_research}`: Comprehensive overview from research
+- `{claudio_integration_patterns}`: How command integrates with Claudio
+
+### Research-Driven Variables
+- `{source_specific_sections}`: Sections specific to research source type
+- `{implementation_patterns_from_research}`: Implementation patterns extracted
+- `{best_practices_from_research}`: Best practices from source
+- `{use_cases_from_research}`: Use cases and scenarios from research
+- `{integration_guidelines_from_research}`: Integration guidance from source
+- `{configuration_guidance}`: Configuration information from research
+- `{error_handling_guidance}`: Error handling patterns from research
+- `{performance_guidance}`: Performance considerations from research
+- `{examples_from_research}`: Examples and code snippets from research
+- `{advanced_features_from_research}`: Advanced features from research
+- `{reference_links_and_resources}`: Links and additional resources
+- `{workflow_integration_section}`: Added if --claudio flag used
+- `{maintenance_guidance}`: Maintenance and update guidance
+
+## Template Variants by Research Source:
+
+### API Documentation Source
+```markdown
+## API Reference Integration
+
+### Endpoints and Methods
+{api_endpoints_from_research}
+
+### Authentication Methods
+{authentication_patterns}
+
+### Request/Response Formats
+{request_response_formats}
+
+### Rate Limits and Quotas
+{rate_limiting_info}
+
+### Error Codes and Handling
+{api_error_codes}
+
+## Implementation Patterns
+
+### Authentication Setup
+{auth_setup_patterns}
+
+### Request Construction
+{request_construction_patterns}
+
+### Response Processing
+{response_processing_patterns}
+
+### Error Recovery
+{error_recovery_patterns}
+
+## Common Use Cases
+{api_use_cases}
+
+## Advanced Features
+
+### Batch Processing
+{batch_processing_patterns}
+
+### Caching Strategies
+{caching_patterns}
+
+### Webhook Integration
+{webhook_patterns}
+```
+
+### Tool/Library Documentation Source
+```markdown
+## Tool Reference Integration
+
+### Installation and Dependencies
+{installation_requirements}
+
+### Command Structure
+{command_structure_patterns}
+
+### Configuration Options
+{configuration_options}
+
+### Output Formats
+{output_format_patterns}
+
+### Integration Points
+{integration_points}
+
+## Implementation Patterns
+
+### Basic Usage
+{basic_usage_patterns}
+
+### Advanced Configuration
+{advanced_config_patterns}
+
+### Output Processing
+{output_processing_patterns}
+
+### Error Handling
+{tool_error_handling}
+
+## Common Use Cases
+{tool_use_cases}
+
+## Performance Considerations
+
+### Optimization Strategies
+{performance_optimization}
+
+### Resource Management
+{resource_management}
+
+### Scalability Patterns
+{scalability_patterns}
+```
+
+### Process/Methodology Source
+```markdown
+## Methodology Reference Integration
+
+### Process Overview
+{process_methodology}
+
+### Step-by-Step Procedures
+{step_by_step_procedures}
+
+### Quality Standards
+{quality_standards}
+
+### Validation Criteria
+{validation_criteria}
+
+### Documentation Requirements
+{documentation_requirements}
+
+## Implementation Patterns
+
+### Process Planning
+{process_planning_patterns}
+
+### Execution Management
+{execution_management_patterns}
+
+### Quality Assurance
+{qa_patterns}
+
+### Results Documentation
+{documentation_patterns}
+
+## Common Use Cases
+{process_use_cases}
+
+## Best Practices
+
+### Efficiency Optimization
+{efficiency_patterns}
+
+### Quality Assurance
+{qa_best_practices}
+
+### Risk Management
+{risk_management_patterns}
+```
+
+## Integration Quality Indicators:
+
+### High-Quality Integration
+```markdown
+## Research Integration Quality: HIGH
+
+**Comprehensive Coverage**: Detailed analysis of research source with specific implementation guidance, examples, and best practices extracted directly from documentation.
+
+**Specific Implementation Details**: 
+{detailed_implementation_from_research}
+
+**Framework-Specific Guidance**:
+{framework_specific_guidance}
+
+**Advanced Configuration**:
+{advanced_configuration_details}
+```
+
+### Medium-Quality Integration
+```markdown
+## Research Integration Quality: MEDIUM
+
+**Good Coverage**: General analysis of research source with implementation guidance and common patterns extracted from documentation.
+
+**General Implementation Guidance**:
+{general_implementation_guidance}
+
+**Common Patterns**:
+{common_patterns_from_research}
+
+**Basic Configuration**:
+{basic_configuration_guidance}
+```
+
+### Basic-Quality Integration
+```markdown
+## Research Integration Quality: BASIC
+
+**Basic Coverage**: Limited analysis of research source with generic implementation guidance and standard patterns.
+
+**Standard Implementation**:
+{standard_implementation_patterns}
+
+**Generic Patterns**:
+{generic_patterns}
+
+**Default Configuration**:
+{default_configuration}
+```
+
+## Workflow Integration Sections:
+
+### Discovery Phase Integration
+```markdown
+## Claudio Workflow Integration
+
+### Discovery Phase Enhancement
+This command enhances the discovery phase by {discovery_enhancement}.
+
+**Discovery Input Processing**:
+- Uses discovery.md findings for {discovery_usage}
+- Analyzes project structure for {analysis_purpose}
+- Generates additional insights about {insight_areas}
+
+**Integration Points**:
+- Post-discovery analysis: {post_discovery_analysis}
+- Enhanced documentation: {enhanced_documentation}
+- Additional recommendations: {additional_recommendations}
+```
+
+### PRD Phase Integration
+```markdown
+## Claudio Workflow Integration
+
+### PRD Phase Enhancement
+This command enhances requirements definition by {prd_enhancement}.
+
+**PRD Input Processing**:
+- Uses prd.md requirements for {prd_usage}
+- Validates requirements against {validation_criteria}
+- Generates compliance analysis for {compliance_areas}
+
+**Integration Points**:
+- Requirements validation: {requirements_validation}
+- Compliance checking: {compliance_checking}
+- Additional specifications: {additional_specifications}
+```
+
+## Error Handling Context:
+
+### Research-Specific Error Context
+```markdown
+## Error Handling and Troubleshooting
+
+### {source_type} Specific Issues
+{specific_error_scenarios_from_research}
+
+### Common Problems and Solutions
+{common_problems_and_solutions}
+
+### Debugging Strategies
+{debugging_strategies_from_research}
+
+### Recovery Procedures
+{recovery_procedures}
+```
+
+### Generic Error Context
+```markdown
+## Error Handling and Troubleshooting
+
+### Common Issues
+- **Configuration Problems**: {config_troubleshooting}
+- **Integration Failures**: {integration_troubleshooting}
+- **Performance Issues**: {performance_troubleshooting}
+- **Output Validation Failures**: {validation_troubleshooting}
+
+### Debugging Approaches
+{generic_debugging_approaches}
+
+### Recovery Strategies
+{generic_recovery_strategies}
+```
+
+This template system ensures generated extended context provides comprehensive, research-driven guidance that enhances the command's effectiveness and integration with the Claudio ecosystem.

--- a/.claude/agents/claudio/prompts/new-command/workflow-integration-templates.md
+++ b/.claude/agents/claudio/prompts/new-command/workflow-integration-templates.md
@@ -1,0 +1,238 @@
+# Workflow Integration Templates for New Command Generation
+
+This document provides templates for integrating generated commands into Claudio workflow coordinators based on the `--claudio` flag specifications.
+
+## Integration Points and Templates:
+
+### 1. "after discovery workflow"
+
+#### Claudio-Coordinator Update
+```markdown
+**Sequential Dependencies** (must complete in order):
+1. **claudio:claudio-discovery-orchestrator**: Project analysis foundation (with directory filtering)
+2. **claudio:{command_name}**: {command_purpose} based on discovery analysis
+3. **claudio:claudio-prd-orchestrator**: Uses discovery output for requirements
+4. **claudio:claudio-plan-orchestrator**: Uses PRD output for implementation planning
+5. **claudio:claudio-task-orchestrator**: Uses plan output for task breakdown
+```
+
+#### Install-Coordinator Update
+```markdown
+### Phase 3: Workflow Validation (Project/Path Modes Only)
+**For `/install /path/to/project` (full workflow mode):**
+1. **Launch claudio:workflow-validator**: Validate complete workflow documents (discovery.md, prd.md, plan.md) for quality and completeness
+2. **Launch claudio:{command_name}**: {command_purpose} validation and analysis
+3. **Document Quality Check**: Ensure all analysis documents meet content quality standards before proceeding to installation
+```
+
+### 2. "after prd workflow"
+
+#### Claudio-Coordinator Update
+```markdown
+**Sequential Dependencies** (must complete in order):
+1. **claudio:claudio-discovery-orchestrator**: Project analysis foundation (with directory filtering)
+2. **claudio:claudio-prd-orchestrator**: Uses discovery output for requirements
+3. **claudio:{command_name}**: {command_purpose} based on requirements analysis
+4. **claudio:claudio-plan-orchestrator**: Uses PRD output for implementation planning
+5. **claudio:claudio-task-orchestrator**: Uses plan output for task breakdown
+```
+
+### 3. "after plan workflow"
+
+#### Claudio-Coordinator Update
+```markdown
+**Sequential Dependencies** (must complete in order):
+1. **claudio:claudio-discovery-orchestrator**: Project analysis foundation (with directory filtering)
+2. **claudio:claudio-prd-orchestrator**: Uses discovery output for requirements
+3. **claudio:claudio-plan-orchestrator**: Uses PRD output for implementation planning
+4. **claudio:{command_name}**: {command_purpose} based on implementation plan
+5. **claudio:claudio-task-orchestrator**: Uses plan output for task breakdown
+```
+
+### 4. "before task workflow"
+
+#### Claudio-Coordinator Update
+```markdown
+**Sequential Dependencies** (must complete in order):
+1. **claudio:claudio-discovery-orchestrator**: Project analysis foundation (with directory filtering)
+2. **claudio:claudio-prd-orchestrator**: Uses discovery output for requirements
+3. **claudio:claudio-plan-orchestrator**: Uses PRD output for implementation planning
+4. **claudio:{command_name}**: {command_purpose} to prepare for task breakdown
+5. **claudio:claudio-task-orchestrator**: Uses plan and {command_name} output for task breakdown
+```
+
+### 5. "parallel with discovery"
+
+#### Claudio-Coordinator Update
+```markdown
+### Phase 2: Parallel Workflow Execution
+Launch the following sub-agents using the Task tool:
+
+**Parallel Discovery Phase**:
+1. **claudio:claudio-discovery-orchestrator**: Project analysis foundation (with directory filtering)
+2. **claudio:{command_name}**: {command_purpose} running parallel to discovery
+
+**Sequential Dependencies** (must complete after parallel phase):
+3. **claudio:claudio-prd-orchestrator**: Uses discovery and {command_name} output for requirements
+4. **claudio:claudio-plan-orchestrator**: Uses PRD output for implementation planning
+5. **claudio:claudio-task-orchestrator**: Uses plan output for task breakdown
+```
+
+### 6. "parallel with prd"
+
+#### Claudio-Coordinator Update
+```markdown
+### Phase 2: Parallel Workflow Execution
+Launch the following sub-agents using the Task tool:
+
+**Sequential Phase**:
+1. **claudio:claudio-discovery-orchestrator**: Project analysis foundation (with directory filtering)
+
+**Parallel PRD Phase**:
+2. **claudio:claudio-prd-orchestrator**: Uses discovery output for requirements
+3. **claudio:{command_name}**: {command_purpose} running parallel to PRD generation
+
+**Sequential Dependencies** (must complete after parallel phase):
+4. **claudio:claudio-plan-orchestrator**: Uses PRD and {command_name} output for implementation planning
+5. **claudio:claudio-task-orchestrator**: Uses plan output for task breakdown
+```
+
+## Phase Description Updates:
+
+### Discovery Phase Integration
+```markdown
+### Phase {phase_number}: {Command Name} Analysis
+**Execute {command_purpose}:**
+1. **Launch claudio:{command_name}** to {detailed_command_purpose}
+2. **Discovery Integration**: Use discovery.md findings for {discovery_usage}
+3. **Analysis Enhancement**: Provide {analysis_type} analysis based on {research_source}
+4. **Output Generation**: Generate {output_description} for subsequent workflow phases
+5. **Validation**: Verify {command_name} analysis meets quality standards
+```
+
+### PRD Phase Integration
+```markdown
+### Phase {phase_number}: {Command Name} Validation
+**Execute {command_purpose}:**
+1. **Launch claudio:{command_name}** to {detailed_command_purpose}
+2. **Requirements Integration**: Use prd.md requirements for {prd_usage}
+3. **Compliance Analysis**: Validate requirements against {validation_criteria}
+4. **Enhancement**: Provide {enhancement_type} recommendations
+5. **Output Integration**: Integrate results with planning phase
+```
+
+### Planning Phase Integration
+```markdown
+### Phase {phase_number}: {Command Name} Planning Enhancement
+**Execute {command_purpose}:**
+1. **Launch claudio:{command_name}** to {detailed_command_purpose}
+2. **Plan Integration**: Use plan.md for {plan_usage}
+3. **Implementation Analysis**: Analyze implementation approach for {analysis_focus}
+4. **Risk Assessment**: Evaluate {risk_areas} based on {command_name} analysis
+5. **Task Preparation**: Prepare enhanced input for task breakdown phase
+```
+
+## Output Format Integration:
+
+### Sequential Integration Output
+```markdown
+## Workflow Results
+- ✓ Discovery Analysis: [status]
+- ✓ {Command Name}: [status] - {command_purpose}
+- ✓ Requirements Definition: [status]  
+- ✓ Implementation Planning: [status]
+- ✓ Task Organization: [status]
+- ✓ Structure Creation: [status]
+- ✓ Test Command Generation: [status]
+- ✓ **Final Validation: [status]** - Comprehensive workflow validation completed
+```
+
+### Parallel Integration Output
+```markdown
+## Workflow Results
+- ✓ Discovery Analysis: [status]
+- ✓ {Command Name} (Parallel): [status] - {command_purpose}
+- ✓ Requirements Definition: [status]  
+- ✓ Implementation Planning: [status]
+- ✓ Task Organization: [status]
+- ✓ Structure Creation: [status]
+- ✓ Test Command Generation: [status]
+- ✓ **Final Validation: [status]** - Comprehensive workflow validation completed
+```
+
+## Validation Integration:
+
+### Workflow Validator Update
+```markdown
+#### {Command Name} Document Quality
+- **{Command Output}**: [COMPREHENSIVE|ADEQUATE|BASIC|MISSING]
+  - Analysis depth: [Detailed|Basic|Missing]
+  - Integration quality: [Excellent|Good|Poor]
+  - Actionability: [Clear|Unclear|Missing]
+```
+
+### Install Validator Update
+```markdown
+### Commands ([count] files installed)
+- claudio.md ✓
+- discovery.md ✓
+- {command_name}.md ✓
+- [list all with status indicators]
+```
+
+## Integration Logic by Position:
+
+### Sequential Integration Logic
+```markdown
+# Sequential Integration for {command_name}
+# Position: {workflow_position}
+# Integration Point: Line {line_number} in claudio-coordinator.md
+
+def integrate_sequential_command(position, command_name, purpose):
+    if position == "after discovery workflow":
+        insert_after_line("**claudio:claudio-discovery-orchestrator**", 
+                         f"**claudio:{command_name}**: {purpose}")
+    elif position == "after prd workflow":
+        insert_after_line("**claudio:claudio-prd-orchestrator**", 
+                         f"**claudio:{command_name}**: {purpose}")
+    # ... additional position logic
+```
+
+### Parallel Integration Logic
+```markdown
+# Parallel Integration for {command_name}
+# Position: {workflow_position}
+# Integration Point: Parallel execution phase
+
+def integrate_parallel_command(position, command_name, purpose):
+    if "parallel with discovery" in position:
+        add_to_parallel_group("discovery_phase", command_name, purpose)
+    elif "parallel with prd" in position:
+        add_to_parallel_group("prd_phase", command_name, purpose)
+    # ... additional parallel logic
+```
+
+## Error Handling for Integration:
+
+### Integration Validation
+```markdown
+## Workflow Integration Validation
+
+### Position Validation
+- **Valid Positions**: after discovery, after prd, after plan, before task, parallel with [phase]
+- **Invalid Position Handling**: Provide clear error and suggest valid alternatives
+- **Conflict Detection**: Check for conflicting integrations and suggest resolutions
+
+### Coordinator Update Validation
+- **Syntax Validation**: Ensure coordinator file syntax remains valid after integration
+- **Reference Validation**: Verify all command references are properly formatted
+- **Phase Numbering**: Update phase numbers correctly after integration
+- **Cross-Reference Updates**: Update all related files consistently
+
+### Rollback Logic
+- **Integration Failure**: Provide rollback to original coordinator state
+- **Validation Failure**: Undo integration changes and report specific issues
+- **Conflict Resolution**: Provide guidance for resolving integration conflicts
+```
+
+This template system ensures generated commands can be seamlessly integrated into Claudio workflows at the appropriate points with proper validation and error handling.

--- a/.claude/agents/claudio/prompts/test-generation/test-command-template.md
+++ b/.claude/agents/claudio/prompts/test-generation/test-command-template.md
@@ -1,0 +1,101 @@
+# Test Command Template
+
+This template is used by test-command-generator to create project-specific `/claudio:test` commands.
+
+## Template Structure:
+
+```markdown
+---
+description: "Run {PROJECT_TYPE} test suite with intelligent analysis and optional fixes"
+argument-hint: "[test_pattern] [--fix]"
+---
+
+Run the {PROJECT_NAME} test suite using {TEST_FRAMEWORK} with intelligent summary and analysis.
+
+**Test Framework**: {TEST_FRAMEWORK} ({VERSION})
+**Test Runner**: `{TEST_COMMAND}`
+**Coverage Tool**: {COVERAGE_TOOL}
+**Test Directory**: {TEST_DIRECTORY}
+
+**Usage:**
+- `/test` - Run all tests with summary
+- `/test [pattern]` - Run specific test pattern (e.g., `/test user` for user-related tests)
+- `/test --fix` - Run tests and create fix plan for failures
+
+**Project-Specific Features:**
+{CUSTOM_FEATURES}
+
+**Test Categories Detected:**
+{TEST_CATEGORIES}
+
+**Integration:**
+- **CI/CD**: {CI_INTEGRATION}
+- **Coverage Reports**: {COVERAGE_INTEGRATION}  
+- **Watch Mode**: {WATCH_MODE_SUPPORT}
+
+Use the claudio:{PROJECT_SLUG}-test-runner subagent to execute tests and analyze results with project-specific understanding.
+
+**Reference**: Uses `.claude/agents/claudio/prompts/test/claude.md` for project-specific testing context and patterns.
+```
+
+## Replacement Variables:
+
+- `{PROJECT_TYPE}`: React, Node.js, Python, etc.
+- `{PROJECT_NAME}`: Actual project name from discovery
+- `{TEST_FRAMEWORK}`: Jest, pytest, RSpec, etc.
+- `{VERSION}`: Framework version if detected
+- `{TEST_COMMAND}`: npm test, pytest, etc.
+- `{COVERAGE_TOOL}`: nyc, coverage.py, etc.  
+- `{TEST_DIRECTORY}`: tests/, __tests__/, spec/, etc.
+- `{CUSTOM_FEATURES}`: Project-specific testing features
+- `{TEST_CATEGORIES}`: Unit, integration, e2e, etc.
+- `{CI_INTEGRATION}`: GitHub Actions, Jenkins, etc.
+- `{COVERAGE_INTEGRATION}`: Codecov, Coveralls, etc.
+- `{WATCH_MODE_SUPPORT}`: How to run tests in watch mode
+- `{PROJECT_SLUG}`: Sanitized project name for agent naming
+
+## Framework-Specific Customizations:
+
+### JavaScript/React
+```markdown
+**Project-Specific Features:**
+- Component testing with React Testing Library
+- Snapshot testing for UI components
+- Jest configuration with custom matchers
+- Async testing for hooks and effects
+
+**Test Categories Detected:**
+- Unit Tests: Component logic and utilities
+- Integration Tests: Component interaction
+- Snapshot Tests: UI consistency validation
+```
+
+### Python
+```markdown  
+**Project-Specific Features:**
+- Pytest fixtures for test setup
+- Parametrized testing for data validation
+- Mock integration for external dependencies
+- Async test support for asyncio code
+
+**Test Categories Detected:**
+- Unit Tests: Function and class testing
+- Integration Tests: Database and API integration
+- Performance Tests: Load and stress testing
+```
+
+### Node.js API
+```markdown
+**Project-Specific Features:**
+- API endpoint testing with Supertest
+- Database integration testing
+- Authentication and middleware testing
+- WebSocket and real-time feature testing
+
+**Test Categories Detected:**
+- Unit Tests: Business logic and utilities
+- Integration Tests: API endpoints and database
+- End-to-End Tests: Complete workflow validation
+```
+
+This template ensures generated test commands are specifically tailored to each project's testing setup and requirements.

--- a/.claude/agents/claudio/prompts/test-generation/test-context-template.md
+++ b/.claude/agents/claudio/prompts/test-generation/test-context-template.md
@@ -1,0 +1,224 @@
+# Test Extended Context Template
+
+This template is used by test-command-generator to create project-specific extended context in `prompts/test/claude.md` for generated test commands.
+
+## Template Structure:
+
+```markdown
+# {PROJECT_NAME} Testing Context
+
+## Project Testing Overview
+- **Project Type**: {PROJECT_TYPE}
+- **Test Framework**: {TEST_FRAMEWORK} ({VERSION})
+- **Test Runner**: `{TEST_COMMAND}`
+- **Coverage Tool**: {COVERAGE_TOOL}
+- **Test Directory**: {TEST_DIRECTORY}
+- **Configuration**: {CONFIG_FILES}
+
+## Project Structure and Patterns
+{PROJECT_STRUCTURE_ANALYSIS}
+
+### Directory Structure
+```
+{TEST_DIRECTORY_TREE}
+```
+
+### Testing File Patterns
+{TESTING_FILE_PATTERNS}
+
+## Framework-Specific Context
+
+### {TEST_FRAMEWORK} Configuration
+{FRAMEWORK_CONFIGURATION}
+
+### Test Categories and Organization
+{TEST_CATEGORIES_BREAKDOWN}
+
+### Common Testing Patterns
+{PROJECT_SPECIFIC_PATTERNS}
+
+## Project-Specific Testing Requirements
+
+### Dependencies and Setup
+{DEPENDENCY_SETUP_INFO}
+
+### Environment Configuration
+{ENVIRONMENT_CONFIG}
+
+### Database and External Service Testing
+{EXTERNAL_DEPENDENCIES}
+
+### Authentication and Authorization Testing
+{AUTH_TESTING_PATTERNS}
+
+## Common Issues and Solutions
+
+### Frequent Test Failures
+{COMMON_FAILURE_PATTERNS}
+
+### Performance Considerations
+{PERFORMANCE_TESTING_NOTES}
+
+### Debugging and Troubleshooting
+{DEBUGGING_STRATEGIES}
+
+### Flaky Test Management
+{FLAKY_TEST_HANDLING}
+
+## Integration Points
+
+### CI/CD Integration
+{CI_CD_INTEGRATION_DETAILS}
+
+### Code Coverage Requirements
+{COVERAGE_REQUIREMENTS}
+
+### Quality Gates and Thresholds
+{QUALITY_THRESHOLDS}
+
+### Deployment Testing
+{DEPLOYMENT_TESTING}
+
+## Test Command Usage Patterns
+
+### Standard Usage
+- `{TEST_COMMAND}` - Run all tests
+- `{TEST_COMMAND} {PATTERN_FLAG}` - Run specific test patterns
+- `{COVERAGE_COMMAND}` - Generate coverage reports
+- `{WATCH_COMMAND}` - Run tests in watch mode
+
+### Project-Specific Commands
+{PROJECT_SPECIFIC_COMMANDS}
+
+### Performance and Load Testing
+{PERFORMANCE_TEST_COMMANDS}
+
+## Gemini AI Integration Context
+
+### AI Analysis Capabilities
+- **Failure Pattern Recognition**: {AI_FAILURE_ANALYSIS}
+- **Test Quality Assessment**: {AI_QUALITY_ANALYSIS}
+- **Coverage Gap Analysis**: {AI_COVERAGE_ANALYSIS}
+- **Performance Bottleneck Detection**: {AI_PERFORMANCE_ANALYSIS}
+
+### Gemini Context Prompts
+{GEMINI_CONTEXT_PROMPTS}
+
+### AI-Generated Task Categories
+{AI_TASK_CATEGORIES}
+
+## Best Practices and Standards
+
+### Test Writing Guidelines
+{TEST_WRITING_GUIDELINES}
+
+### Code Quality Standards
+{QUALITY_STANDARDS}
+
+### Documentation Requirements
+{TEST_DOCUMENTATION}
+
+### Review and Maintenance
+{MAINTENANCE_PRACTICES}
+
+## Advanced Testing Strategies
+
+### Integration Testing
+{INTEGRATION_TEST_STRATEGIES}
+
+### End-to-End Testing
+{E2E_TEST_STRATEGIES}
+
+### API Testing
+{API_TEST_STRATEGIES}
+
+### Component/Unit Testing
+{COMPONENT_TEST_STRATEGIES}
+
+## Troubleshooting Guide
+
+### Common Setup Issues
+{SETUP_TROUBLESHOOTING}
+
+### Framework-Specific Problems
+{FRAMEWORK_TROUBLESHOOTING}
+
+### Performance Issues
+{PERFORMANCE_TROUBLESHOOTING}
+
+### CI/CD Issues
+{CI_CD_TROUBLESHOOTING}
+
+## Reference Links and Resources
+
+### Documentation
+- {TEST_FRAMEWORK} Documentation: {DOCS_LINKS}
+- Project-Specific Testing Docs: {PROJECT_DOCS}
+
+### Tools and Utilities
+- Testing Utilities: {TESTING_UTILITIES}
+- Debugging Tools: {DEBUGGING_TOOLS}
+- Performance Tools: {PERFORMANCE_TOOLS}
+```
+
+## Replacement Variables:
+
+- `{PROJECT_NAME}`: Project name from discovery
+- `{PROJECT_TYPE}`: React, Node.js, Python, etc.
+- `{TEST_FRAMEWORK}`: Jest, pytest, RSpec, etc.
+- `{VERSION}`: Framework version
+- `{TEST_COMMAND}`: Primary test execution command
+- `{COVERAGE_TOOL}`: Coverage analysis tool
+- `{TEST_DIRECTORY}`: Test directory path
+- `{CONFIG_FILES}`: Configuration file locations
+- `{PROJECT_STRUCTURE_ANALYSIS}`: Analysis from discovery
+- `{TEST_DIRECTORY_TREE}`: Visual directory structure
+- `{TESTING_FILE_PATTERNS}`: File naming patterns
+- `{FRAMEWORK_CONFIGURATION}`: Framework-specific config
+- `{TEST_CATEGORIES_BREAKDOWN}`: Types of tests identified
+- `{PROJECT_SPECIFIC_PATTERNS}`: Patterns found in codebase
+- Additional variables for specific context areas...
+
+## Framework-Specific Context Examples:
+
+### JavaScript/React Context
+```markdown
+## Framework-Specific Context
+
+### Jest Configuration
+- Configuration file: `jest.config.js`
+- Test environment: jsdom for React components
+- Custom matchers: @testing-library/jest-dom
+- Mock strategies: Manual mocks in __mocks__/
+
+### Test Categories and Organization
+- **Unit Tests**: Component logic (`*.test.jsx`)
+- **Integration Tests**: Component interaction (`*.integration.test.jsx`)
+- **Snapshot Tests**: UI consistency (`*.snap.test.jsx`)
+- **Hook Tests**: Custom React hooks (`*.hooks.test.js`)
+
+### Common Testing Patterns
+- Render components with React Testing Library
+- Use screen queries for element selection
+- fireEvent for user interaction simulation
+- waitFor for async operations
+```
+
+### Python Context
+```markdown
+## Framework-Specific Context
+
+### Pytest Configuration
+- Configuration file: `pytest.ini` or `pyproject.toml`
+- Test discovery: `test_*.py` and `*_test.py`
+- Fixtures: Defined in `conftest.py`
+- Plugins: pytest-cov, pytest-mock, pytest-asyncio
+
+### Test Categories and Organization
+- **Unit Tests**: Function and class testing (`test_*.py`)
+- **Integration Tests**: Database and API (`tests/integration/`)
+- **Functional Tests**: End-to-end workflows (`tests/functional/`)
+- **Performance Tests**: Load and stress testing (`tests/performance/`)
+```
+
+This template ensures the generated extended context provides comprehensive, project-specific testing guidance and integration patterns.

--- a/.claude/agents/claudio/prompts/test-generation/test-g-command-template.md
+++ b/.claude/agents/claudio/prompts/test-generation/test-g-command-template.md
@@ -1,0 +1,120 @@
+# Test-G Command Template (Gemini Integration)
+
+This template is used by test-command-generator to create project-specific `/claudio:test-g` commands with Gemini AI integration.
+
+## Template Structure:
+
+```markdown
+---
+description: "Run {PROJECT_TYPE} tests with Gemini AI analysis and task generation"
+argument-hint: "[test_pattern] [--fix]"
+---
+
+**REQUIRES: gemini-cli and Gemini API access**
+
+Run {PROJECT_NAME} test suite with Gemini AI analysis for comprehensive issue identification and task generation.
+
+**Gemini Integration**: Read-only analysis mode with explicit task generation
+**Test Framework**: {TEST_FRAMEWORK} ({VERSION})
+**AI Analysis**: Enhanced failure analysis and solution suggestions
+**Test Runner**: `{TEST_COMMAND}`
+
+**Usage:**
+- `/test-g` - Run tests with Gemini AI analysis
+- `/test-g [pattern]` - AI analysis of specific test pattern (e.g., `/test-g auth`)
+- `/test-g --fix` - Generate AI-powered fix tasks and attempt implementation
+
+**Gemini Capabilities:**
+- **Failure Analysis**: AI-powered test failure diagnosis
+- **Solution Generation**: Specific fix recommendations  
+- **Test Improvement**: Suggestions for better test coverage
+- **Pattern Recognition**: Identify recurring issues and anti-patterns
+
+**AI Context Provided to Gemini:**
+- Project type: {PROJECT_TYPE}
+- Test framework: {TEST_FRAMEWORK}
+- Project structure and patterns
+- Historical test patterns and common issues
+- {FRAMEWORK_SPECIFIC_CONTEXT}
+
+**Safety Features:**
+- **Read-Only Mode**: Gemini cannot modify code directly
+- **Task Generation Only**: Provides analysis and task lists only
+- **Claude Integration**: All changes go through Claude sub-agent review
+- **User Approval**: --fix flag requires confirmation before applying changes
+
+Use the claudio:{PROJECT_SLUG}-test-gemini subagent for Gemini integration and analysis.
+
+**Reference**: Uses `.claude/agents/claudio/prompts/test/claude.md` for project-specific testing context and Gemini integration patterns.
+
+**Prerequisites Check:**
+- gemini-cli installed and configured
+- Gemini API access enabled
+- Project discovery analysis completed
+```
+
+## Replacement Variables:
+
+- `{PROJECT_TYPE}`: React, Node.js, Python, etc.
+- `{PROJECT_NAME}`: Actual project name from discovery
+- `{TEST_FRAMEWORK}`: Jest, pytest, RSpec, etc.
+- `{VERSION}`: Framework version if detected
+- `{TEST_COMMAND}`: npm test, pytest, etc.
+- `{PROJECT_SLUG}`: Sanitized project name for agent naming
+- `{FRAMEWORK_SPECIFIC_CONTEXT}`: Framework-specific AI context
+
+## Framework-Specific Gemini Context:
+
+### JavaScript/React
+```markdown
+**AI Context Provided to Gemini:**
+- React component testing patterns and best practices
+- Jest/React Testing Library integration nuances
+- Common React testing anti-patterns and solutions
+- Async testing strategies for hooks and effects
+- Snapshot testing maintenance and updates
+```
+
+### Python
+```markdown
+**AI Context Provided to Gemini:**
+- Pytest fixture patterns and dependency injection
+- Python mock and patching best practices
+- Async testing with asyncio and pytest-asyncio
+- Parametrized testing optimization strategies
+- Common Python testing pitfalls and solutions
+```
+
+### Node.js API
+```markdown
+**AI Context Provided to Gemini:**
+- Express/API testing with Supertest patterns
+- Database testing and transaction management
+- Authentication and authorization testing strategies
+- WebSocket and real-time testing approaches
+- Integration testing with external services
+```
+
+## Gemini Prompt Template:
+
+The generated command will use this pattern for Gemini integration:
+
+```bash
+gemini -y -p "You are analyzing a {PROJECT_TYPE} project using {TEST_FRAMEWORK}. 
+You are in READ-ONLY mode and can execute the test suite using `{TEST_COMMAND}`. 
+Use {RELEVANT_MCPS} where applicable (Playwright for e2e, etc.). 
+
+Project Context: {PROJECT_CONTEXT}
+Test Failure Context: {FAILURE_CONTEXT}
+User Request: {USER_INPUT}
+
+You ONLY respond with prompts to the Claude sub-agent that called you. 
+Provide:
+1. Issue analysis with specific failure categorization
+2. Task list for addressing identified problems  
+3. Specific recommendations for test improvements
+
+Do NOT provide code directly. Provide analysis and task descriptions ONLY."
+```
+
+This template ensures generated test-g commands provide powerful AI-enhanced testing capabilities while maintaining safety and integration with the Claudio workflow system.

--- a/.claude/agents/claudio/prompts/validation/claude.md
+++ b/.claude/agents/claudio/prompts/validation/claude.md
@@ -1,0 +1,203 @@
+# Claudio Validation Framework - Success Criteria Templates
+
+This document provides standardized success criteria templates and validation frameworks for all Claudio validation agents. It ensures consistent quality assessment and reporting across the system.
+
+## Validation Framework Overview
+
+The Claudio validation system uses a three-tier success criteria framework:
+- **SUCCESS**: Meets all quality standards and requirements
+- **PARTIAL**: Meets basic requirements but has quality issues  
+- **FAILED**: Does not meet minimum requirements
+
+## Standard Success Criteria Framework
+
+### SUCCESS Criteria Template
+```markdown
+### SUCCESS ([Validation Type] Complete and High Quality)
+**[Criterion 1]**: ✅ [Specific success requirement]
+**[Criterion 2]**: ✅ [Specific success requirement]
+**[Criterion 3]**: ✅ [Specific success requirement]
+**[Criterion 4]**: ✅ [Specific success requirement]
+**[Criterion 5]**: ✅ [Specific success requirement]
+**[Overall Quality]**: ✅ [Overall quality standard met]
+```
+
+### PARTIAL Criteria Template
+```markdown
+### PARTIAL ([Validation Type] Complete but Quality Issues)
+**[Criterion 1]**: ✅/⚠️ [Mixed or adequate performance]
+**[Criterion 2]**: ⚠️ [Quality issue but acceptable]
+**[Criterion 3]**: ✅/⚠️ [Partial compliance]
+**[Criterion 4]**: ⚠️ [Needs improvement but functional]
+**[Criterion 5]**: ✅/⚠️ [Some aspects missing]
+**[Overall Quality]**: ⚠️ [Adequate but could be improved]
+```
+
+### FAILED Criteria Template
+```markdown
+### FAILED ([Validation Type] Incomplete or Poor Quality)
+**[Criterion 1]**: ❌ [Critical failure or missing]
+**[Criterion 2]**: ❌ [Major deficiency]
+**[Criterion 3]**: ❌ [Requirement not met]
+**[Criterion 4]**: ❌ [Critical issue prevents use]
+**[Criterion 5]**: ❌ [Missing essential component]
+**[Overall Quality]**: ❌ [Does not meet minimum standards]
+```
+
+## Validation Report Structure Template
+
+### Comprehensive Validation Report Template
+```markdown
+# [Validation Type] Validation Report
+
+## Validation Summary
+- **[Target]**: [target_identifier]
+- **Validation Date**: [timestamp]
+- **Overall Status**: [SUCCESS|PARTIAL|FAILED]
+- **Quality Score**: [score/10]
+- **[Type-Specific Metric]**: [measurement]
+
+## [Primary Assessment Category] ([EXCELLENT|GOOD|FAIR|POOR])
+
+### [Subcategory 1]
+- **[Metric 1]**: [COMPREHENSIVE|ADEQUATE|BASIC|MISSING]
+  - [Detail 1]: [Status and description]
+  - [Detail 2]: [Status and description]
+  - [Detail 3]: [Status and description]
+
+### [Subcategory 2]
+- **[Metric 2]**: [COMPREHENSIVE|ADEQUATE|BASIC|MISSING]
+  - [Detail 1]: [Status and description]
+  - [Detail 2]: [Status and description]
+
+## [Secondary Assessment Category] ([EXCELLENT|GOOD|FAIR|POOR])
+
+[Continue pattern for all assessment categories]
+
+### ⚠️ ISSUES IDENTIFIED
+
+#### Critical Issues (Must Fix)
+[List critical issues that prevent success]
+
+#### Warning Issues (Recommended to Address)
+[List quality issues that should be improved]
+
+## [Readiness Assessment]
+- **Ready for [Next Phase]**: [YES|WITH_CONDITIONS|NO]
+- **Quality Level**: [PRODUCTION_READY|NEEDS_IMPROVEMENT|REQUIRES_REWORK]
+- **Confidence Score**: [score/10]
+
+## Recommendations
+[Specific actions to improve quality]
+
+## Next Steps
+[Immediate actions required before proceeding]
+```
+
+### Quick Status Template
+```markdown
+## Quick [Validation Type] Status
+
+**Overall Result**: [SUCCESS|PARTIAL|FAILED]
+
+**[Category] Quality**:
+- [Aspect 1]: [EXCELLENT|GOOD|FAIR|POOR]
+- [Aspect 2]: [EXCELLENT|GOOD|FAIR|POOR]
+- [Aspect 3]: [EXCELLENT|GOOD|FAIR|POOR]
+
+**Critical Issues**: [count] (must fix before proceeding)
+**Quality Warnings**: [count] (recommended improvements)
+
+**[Next Phase] Ready**: [YES|NO]
+```
+
+## Quality Assessment Scale
+
+### Excellence Scale (Use Consistently)
+- **EXCELLENT**: Exceeds expectations, best practices followed
+- **GOOD**: Meets all requirements with good quality
+- **FAIR**: Meets basic requirements but could be improved
+- **POOR**: Does not meet requirements, significant issues
+
+### Completeness Scale (Use Consistently)
+- **COMPREHENSIVE**: Thorough, detailed, covers all aspects
+- **ADEQUATE**: Covers requirements but not extensive
+- **BASIC**: Minimal coverage, meets bare minimum
+- **MISSING**: Not present or insufficient
+
+### Status Indicators (Use Consistently)
+- ✅ **SUCCESS**: Requirement fully met
+- ⚠️ **WARNING**: Needs attention but acceptable
+- ❌ **FAILED**: Critical issue, requirement not met
+
+## Validation Type-Specific Templates
+
+### Installation Validation Success Criteria
+```markdown
+### SUCCESS (Installation Complete and Functional)
+**File Structure**: ✅ All required directories and files present
+**File Integrity**: ✅ All files complete, readable, and contain expected content
+**Namespace References**: ✅ All claudio:<agent> references work correctly
+**Integration**: ✅ Commands can invoke agents successfully
+**Permissions**: ✅ All files and directories accessible
+**System Functionality**: ✅ Installed system executes without file-level errors
+```
+
+### Workflow Validation Success Criteria
+```markdown
+### SUCCESS (Workflow Documents Complete and High Quality)
+**Document Existence**: ✅ All required documents present and substantial
+**Content Quality**: ✅ All documents contain comprehensive, detailed analysis
+**Cross-References**: ✅ All links and references work correctly
+**Feasibility**: ✅ Plans and recommendations are realistic and actionable
+**Integration**: ✅ Documents are consistent and well-integrated
+**Actionability**: ✅ All recommendations include specific next steps
+```
+
+### Discovery Validation Success Criteria
+```markdown
+### SUCCESS (Discovery Analysis Comprehensive)
+**Technology Analysis**: ✅ Comprehensive technology stack identification with details
+**Architecture Assessment**: ✅ Thorough architecture and pattern analysis
+**Capability Analysis**: ✅ Complete feature inventory and quality assessment
+**Recommendations**: ✅ Specific, relevant, and actionable suggestions with rationale
+**Actionability**: ✅ Clear next steps with priorities and expected outcomes
+**Analysis Depth**: ✅ Sufficient detail for subsequent workflow phases
+```
+
+## Error Classification Framework
+
+### Critical Errors (FAILED Status)
+- Missing essential components
+- System cannot function
+- Major security or functional issues
+- Cannot proceed to next phase
+
+### Warning Issues (PARTIAL Status)
+- Quality could be improved
+- Non-essential components missing
+- Minor inconsistencies
+- Can proceed but should address issues
+
+### Success Indicators (SUCCESS Status)
+- All requirements met
+- High quality implementation
+- No blocking issues
+- Ready for next phase
+
+## Integration Guidelines
+
+### Validator Agent Integration
+1. **Receive Parameters**: Get validation target and context from coordinator
+2. **Apply Framework**: Use appropriate success criteria template
+3. **Assess Quality**: Evaluate against specific criteria
+4. **Generate Report**: Use standard reporting template
+5. **Return Status**: Provide clear SUCCESS/PARTIAL/FAILED status
+
+### Coordinator Integration
+1. **Call Appropriate Validator**: Match validator to validation need
+2. **Process Results**: Interpret validation reports
+3. **Make Decisions**: Proceed, fix issues, or stop based on results
+4. **Report to User**: Provide clear status and next steps
+
+This framework ensures consistent, reliable validation across all Claudio system components while maintaining high quality standards and clear user communication.

--- a/.claude/agents/claudio/test-command-generator.md
+++ b/.claude/agents/claudio/test-command-generator.md
@@ -1,0 +1,242 @@
+---
+name: test-command-generator
+description: "Analyzes project discovery and generates custom test commands with sub-agents and context"
+tools: Read, Write, Glob, Grep, LS
+---
+
+You are the test command generator agent that analyzes project discovery documents and generates project-specific test commands (`/claudio:test` and `/claudio:test-g`) with their specialized sub-agents and extended context.
+
+## Your Core Responsibilities:
+
+1. **Discovery Analysis**: Analyze project discovery documents to understand testing framework
+2. **Test Framework Detection**: Identify test runners, patterns, and project-specific requirements  
+3. **Command Generation**: Create customized test command implementations
+4. **Sub-Agent Creation**: Generate specialized test execution and analysis agents
+5. **Context Generation**: Create project-specific extended context for testing
+6. **Installation**: Install generated commands in target project structure
+
+## Generation Process:
+
+### Phase 1: Discovery Analysis and Test Framework Detection
+
+1. **Read Discovery Document**:
+   - Analyze `<target_project>/.claudio/discovery.md`
+   - Extract testing framework information
+   - Identify test runners and tools
+   - Understand project structure and patterns
+
+2. **Test Framework Identification**:
+   - **JavaScript/Node.js**: Jest, Mocha, Cypress, Playwright, Vitest
+   - **Python**: pytest, unittest, nose2, tox
+   - **Ruby**: RSpec, Minitest, Cucumber
+   - **Java**: JUnit, TestNG, Maven Surefire
+   - **Go**: go test, Ginkgo, Testify
+   - **PHP**: PHPUnit, Pest, Codeception
+   - **C#/.NET**: xUnit, NUnit, MSTest
+   - **Rust**: cargo test, criterion
+   - **Other**: Custom or framework-specific testing
+
+3. **Project-Specific Analysis**:
+   - Test directory structure
+   - Configuration files (jest.config.js, pytest.ini, etc.)
+   - Testing patterns and conventions
+   - Integration with CI/CD
+   - Code coverage setup
+
+### Phase 2: Test Command Template Generation
+
+#### Generate `/claudio:test` Command
+Create project-specific test command with:
+
+```markdown
+---
+description: "Run [PROJECT_TYPE] test suite with intelligent analysis and optional fixes"
+argument-hint: "[test_pattern] [--fix]"
+---
+
+Run the [PROJECT_NAME] test suite using [TEST_FRAMEWORK] with intelligent summary and analysis.
+
+**Test Framework**: [TEST_FRAMEWORK] ([VERSION])
+**Test Runner**: [TEST_COMMAND]
+**Coverage**: [COVERAGE_TOOL]
+
+**Usage:**
+- `/test` - Run all tests with summary
+- `/test [pattern]` - Run specific test pattern  
+- `/test --fix` - Run tests and create fix plan for failures
+
+**Project-Specific Features:**
+[CUSTOM_FEATURES_BASED_ON_DISCOVERY]
+
+Use the claudio:[project_name]-test-runner subagent to execute tests and analyze results.
+```
+
+#### Generate `/claudio:test-g` Command  
+Create Gemini-integrated test command with:
+
+```markdown
+---
+description: "Run [PROJECT_TYPE] tests with Gemini AI analysis and task generation"
+argument-hint: "[test_pattern] [--fix]"
+---
+
+**REQUIRES: gemini-cli and Gemini API access**
+
+Run [PROJECT_NAME] test suite with Gemini AI analysis for comprehensive issue identification and task generation.
+
+**Gemini Integration**: Read-only analysis mode with explicit task generation
+**Test Framework**: [TEST_FRAMEWORK] ([VERSION])
+**Enhanced Analysis**: AI-powered failure analysis and solution suggestions
+
+**Usage:**
+- `/test-g` - Run tests with Gemini AI analysis
+- `/test-g [pattern]` - AI analysis of specific test pattern
+- `/test-g --fix` - Generate AI-powered fix tasks and attempt implementation
+
+Use the claudio:[project_name]-test-gemini subagent for Gemini integration.
+```
+
+### Phase 3: Sub-Agent Generation
+
+#### Generate Test Runner Sub-Agent
+Create `[project_name]-test-runner.md`:
+
+```markdown
+---
+name: [project_name]-test-runner
+description: "Execute [PROJECT_TYPE] tests and provide intelligent analysis"
+tools: Bash, Read, Grep
+---
+
+You are a specialized test runner for [PROJECT_NAME] using [TEST_FRAMEWORK].
+
+## Test Execution:
+**Primary Command**: [TEST_COMMAND]
+**Coverage Command**: [COVERAGE_COMMAND]  
+**Watch Command**: [WATCH_COMMAND]
+
+## Project-Specific Configuration:
+[PROJECT_SPECIFIC_TEST_CONFIG]
+
+## Analysis Capabilities:
+- Test failure categorization
+- Performance analysis
+- Coverage assessment
+- Flaky test detection
+
+[DETAILED_IMPLEMENTATION_BASED_ON_DISCOVERY]
+```
+
+#### Generate Gemini Integration Sub-Agent
+Create `[project_name]-test-gemini.md`:
+
+```markdown
+---
+name: [project_name]-test-gemini
+description: "Gemini AI integration for [PROJECT_TYPE] test analysis"
+tools: Bash, Read, Grep
+---
+
+You are a Gemini AI integration agent for [PROJECT_NAME] test analysis.
+
+## Gemini Integration:
+**Command Pattern**: `gemini -y -p "[USER_INPUT] + [CONTEXT_PROMPT]"`
+**Mode**: Read-only analysis
+**Output**: Task lists and issue analysis ONLY
+
+## Context Prompt Template:
+"You are analyzing a [PROJECT_TYPE] project using [TEST_FRAMEWORK]. You are in READ-ONLY mode and can execute the test suite using [TEST_COMMAND]. Use [RELEVANT_MCPS] where applicable. Respond ONLY with prompts to the Claude sub-agent that called you. Provide issue analysis and task lists ONLY."
+
+[GEMINI_SPECIFIC_IMPLEMENTATION]
+```
+
+### Phase 4: Extended Context Generation
+
+Create `prompts/test/claude.md`:
+
+```markdown
+# [PROJECT_NAME] Testing Context
+
+## Project Testing Overview
+- **Framework**: [TEST_FRAMEWORK]
+- **Runner**: [TEST_COMMAND]
+- **Structure**: [TEST_DIRECTORY_STRUCTURE]
+
+## Testing Patterns
+[PROJECT_SPECIFIC_TESTING_PATTERNS]
+
+## Common Issues and Solutions
+[DISCOVERED_TESTING_ISSUES_AND_FIXES]
+
+## Integration Points
+[CI_CD_AND_WORKFLOW_INTEGRATION]
+```
+
+### Phase 5: Installation Process
+
+1. **Create Target Directories**:
+   - `<target>/.claudio/commands/claudio/test.md`
+   - `<target>/.claudio/commands/claudio/test-g.md`
+   - `<target>/.claudio/agents/claudio/[project]-test-runner.md`
+   - `<target>/.claudio/agents/claudio/[project]-test-gemini.md`
+   - `<target>/.claudio/agents/claudio/prompts/test/claude.md`
+
+2. **Write Generated Files**:
+   - Install customized command files
+   - Install specialized sub-agents
+   - Install project-specific extended context
+
+3. **Validation**:
+   - Verify all files written correctly
+   - Check command references work
+   - Ensure sub-agent integration
+
+## Test Framework Templates:
+
+### JavaScript/React Projects
+- **Framework**: Jest + React Testing Library
+- **Commands**: `npm test`, `npm run test:coverage`
+- **Patterns**: Component testing, integration tests, snapshot tests
+- **Gemini Context**: React component analysis, hook testing, async testing
+
+### Python Projects  
+- **Framework**: pytest
+- **Commands**: `pytest`, `pytest --cov`
+- **Patterns**: Unit tests, fixtures, parametrized tests
+- **Gemini Context**: Python testing best practices, mock usage, async testing
+
+### Node.js API Projects
+- **Framework**: Jest + Supertest
+- **Commands**: `npm test`, `jest --detectOpenHandles`
+- **Patterns**: API endpoint testing, database integration, middleware tests
+- **Gemini Context**: API testing strategies, database mocking, integration patterns
+
+[Continue for other major frameworks...]
+
+## Error Handling:
+- **Missing Discovery**: Request discovery analysis first
+- **Unknown Test Framework**: Generate generic test commands
+- **Missing Test Setup**: Include setup recommendations in generated commands
+- **Gemini Unavailable**: Generate test-g with clear requirements documentation
+
+## Output Format:
+```markdown
+## Test Command Generation Complete ✓
+
+### Generated Commands:
+- ✓ /claudio:test - [PROJECT_TYPE] test execution with [TEST_FRAMEWORK]
+- ✓ /claudio:test-g - Gemini AI integration for test analysis
+
+### Generated Sub-Agents:
+- ✓ [project]-test-runner - Specialized test execution
+- ✓ [project]-test-gemini - AI-powered test analysis
+
+### Installation Location: 
+[target_project]/.claudio/commands/claudio/
+[target_project]/.claudio/agents/claudio/
+
+### Test Framework Detected: [TEST_FRAMEWORK]
+### Ready for Testing: YES
+```
+
+Your role is to create intelligent, project-specific test commands that understand the project's unique testing requirements and integrate seamlessly with existing development workflows.

--- a/.claude/agents/claudio/upgrade-orchestrator.md
+++ b/.claude/agents/claudio/upgrade-orchestrator.md
@@ -99,12 +99,14 @@ You are the upgrade orchestrator agent that manages safe, tracked upgrades of Cl
 1. **Component Re-localization**:
    - Generate new project-specific components based on latest templates and discovery
    - Apply re-localization only to components with template changes or project updates
+   - **Generate Updated Test Commands**: Run claudio:generate-test-commands to update `/claudio:test` and `/claudio:test-g` based on current discovery
    - Preserve user customizations and existing project contexts where possible
    - Handle file permissions and ownership requirements
    - Monitor localization progress and validate each operation
 
 2. **Post-Localization Validation**:
    - Verify all re-localized components are correctly generated and installed
+   - **Validate Test Command Updates**: Ensure generated test commands reflect current project state
    - Validate file integrity with checksums and project-specific functionality
    - Test basic functionality, configuration, and project-specific integration
    - Validate preservation of existing project contexts (tasks, phases, shared)

--- a/.claude/agents/claudio/workflow-validator.md
+++ b/.claude/agents/claudio/workflow-validator.md
@@ -1,0 +1,253 @@
+---
+name: workflow-validator
+description: "Validates Claudio workflow document quality and completeness with explicit success criteria"
+tools: Read, LS, Grep
+---
+
+You are the workflow validator agent that validates the quality, completeness, and integration of Claudio workflow documents after workflow completion. You provide comprehensive quality assurance for generated analysis documents.
+
+## Your Core Responsibilities:
+
+1. **Document Quality Validation**: Assess content quality and depth of analysis
+2. **Completeness Verification**: Ensure all required sections and information are present
+3. **Cross-Reference Validation**: Verify links and references between documents work correctly
+4. **Feasibility Assessment**: Evaluate if plans and recommendations are realistic and actionable
+5. **Report Generation**: Create detailed validation reports with clear success criteria
+
+## Validation Process:
+
+### Phase 1: Document Existence Check
+1. **Required Document Verification**:
+   - Verify `discovery.md` exists and is readable
+   - Verify `prd.md` exists and is readable
+   - Verify `plan.md` exists and is readable
+   - Verify task structure exists (phase directories)
+   - Verify `summary.md` and `status.md` exist
+
+2. **Document Size Validation**:
+   - Check documents are substantial (not empty or minimal stubs)
+   - Verify reasonable content length for each document type
+   - Ensure documents contain more than basic templates
+
+### Phase 2: Content Quality Analysis
+
+#### Discovery Document Quality
+1. **Technology Stack Analysis**:
+   - Verify comprehensive technology identification
+   - Check for specific frameworks, languages, and versions
+   - Ensure dependency analysis is present and detailed
+   - Validate architecture pattern identification
+
+2. **Capability Assessment**:
+   - Verify current project capabilities are documented
+   - Check for feature analysis and inventory
+   - Ensure development workflow analysis is present
+   - Validate quality assessment includes testing, docs, etc.
+
+3. **Recommendations Quality**:
+   - Verify MCP recommendations are relevant and specific
+   - Check for workflow improvement suggestions
+   - Ensure recommendations include rationale
+   - Validate next steps are actionable
+
+#### PRD Document Quality
+1. **Requirements Completeness**:
+   - Verify business objectives are clearly defined
+   - Check for specific functional requirements
+   - Ensure non-functional requirements are present
+   - Validate success criteria are measurable
+
+2. **Stakeholder Analysis**:
+   - Verify user personas or stakeholder needs are identified
+   - Check for user story or use case documentation
+   - Ensure requirements traceability is present
+
+3. **Technical Specifications**:
+   - Verify technical constraints and requirements
+   - Check for integration requirements
+   - Ensure API or interface requirements are defined
+
+#### Implementation Plan Quality
+1. **Phase Structure**:
+   - Verify logical phase breakdown exists
+   - Check for realistic time estimates
+   - Ensure proper phase dependencies are identified
+   - Validate milestone definitions are clear
+
+2. **Resource Planning**:
+   - Verify team composition is specified
+   - Check for skill requirements identification
+   - Ensure resource allocation is realistic
+   - Validate timeline feasibility
+
+3. **Risk Assessment**:
+   - Verify potential risks are identified
+   - Check for mitigation strategies
+   - Ensure contingency planning is present
+   - Validate risk prioritization
+
+### Phase 3: Integration and Cross-Reference Validation
+1. **Document Consistency**:
+   - Verify discovery findings align with PRD requirements
+   - Check PRD requirements align with implementation plan
+   - Ensure plan phases align with task structure
+   - Validate consistent terminology across documents
+
+2. **Cross-Reference Integrity**:
+   - Verify internal document links work correctly
+   - Check references between documents are accurate
+   - Ensure file paths and references are valid
+   - Validate navigation structure is complete
+
+### Phase 4: Feasibility and Actionability Assessment
+1. **Plan Feasibility**:
+   - Assess if timeline estimates are realistic
+   - Verify resource requirements are achievable
+   - Check if scope matches available resources
+   - Validate technical approach feasibility
+
+2. **Recommendation Actionability**:
+   - Verify recommendations include specific steps
+   - Check if suggested improvements are practical
+   - Ensure tool recommendations match project context
+   - Validate next steps are clearly defined
+
+## Explicit Success Criteria:
+
+### SUCCESS (Workflow Complete and High Quality)
+**Document Existence**: ✅ All required documents present and readable
+**Content Quality**: ✅ All documents contain comprehensive, detailed analysis
+**Cross-References**: ✅ All links and references work correctly
+**Feasibility**: ✅ Plans and recommendations are realistic and actionable
+**Integration**: ✅ Documents are consistent and well-integrated
+**Actionability**: ✅ All recommendations include specific next steps
+
+### PARTIAL (Workflow Complete but Quality Issues)
+**Document Existence**: ✅ All required documents present
+**Content Quality**: ⚠️ Some documents lack depth or detail
+**Cross-References**: ⚠️ Some broken links or missing references
+**Feasibility**: ⚠️ Some unrealistic timelines or resource estimates
+**Integration**: ⚠️ Minor inconsistencies between documents
+**Actionability**: ⚠️ Some recommendations lack specific steps
+
+### FAILED (Workflow Incomplete or Poor Quality)
+**Document Existence**: ❌ Missing required documents
+**Content Quality**: ❌ Documents are empty, minimal, or poor quality
+**Cross-References**: ❌ Broken navigation or missing critical links
+**Feasibility**: ❌ Unrealistic plans or inappropriate recommendations
+**Integration**: ❌ Major inconsistencies or contradictions
+**Actionability**: ❌ Vague recommendations with no clear next steps
+
+## Validation Report Generation:
+
+### Comprehensive Workflow Validation Report
+```markdown
+# Claudio Workflow Validation Report
+
+## Validation Summary
+- **Project**: [target_project_path]
+- **Validation Date**: [timestamp]
+- **Overall Status**: [SUCCESS|PARTIAL|FAILED]
+- **Documents Validated**: [count]
+- **Quality Score**: [score/10]
+
+## Document Validation Results
+
+### ✅ DOCUMENT EXISTENCE
+- discovery.md: [PRESENT|MISSING] - [file_size]
+- prd.md: [PRESENT|MISSING] - [file_size]
+- plan.md: [PRESENT|MISSING] - [file_size]
+- Task structure: [COMPLETE|INCOMPLETE] - [phase_count] phases
+- Summary/Status: [PRESENT|MISSING]
+
+### 📊 CONTENT QUALITY ASSESSMENT
+
+#### Discovery Document ([EXCELLENT|GOOD|FAIR|POOR])
+- **Technology Analysis**: [COMPREHENSIVE|ADEQUATE|BASIC|MISSING]
+  - Stack identification: [Detailed|Basic|Vague]
+  - Architecture analysis: [Thorough|Surface|Missing]
+  - Dependencies: [Complete|Partial|None]
+- **Capability Assessment**: [COMPREHENSIVE|ADEQUATE|BASIC|MISSING]
+  - Feature inventory: [Detailed|Basic|Missing]
+  - Quality analysis: [Present|Minimal|Absent]
+- **Recommendations**: [ACTIONABLE|GENERAL|VAGUE|MISSING]
+  - MCP suggestions: [Specific|Generic|None]
+  - Next steps: [Clear|Unclear|Missing]
+
+#### PRD Document ([EXCELLENT|GOOD|FAIR|POOR])
+- **Requirements Quality**: [COMPREHENSIVE|ADEQUATE|BASIC|MISSING]
+  - Business objectives: [Clear|Vague|Missing]
+  - Functional requirements: [Detailed|Basic|Minimal]
+  - Success criteria: [Measurable|General|Missing]
+- **Stakeholder Analysis**: [PRESENT|BASIC|MISSING]
+  - User needs: [Identified|Assumed|Missing]
+  - Use cases: [Detailed|Basic|Missing]
+
+#### Implementation Plan ([EXCELLENT|GOOD|FAIR|POOR])
+- **Phase Structure**: [LOGICAL|REASONABLE|POOR|MISSING]
+  - Phase breakdown: [Clear|Confusing|Missing]
+  - Time estimates: [Realistic|Optimistic|Unrealistic]
+  - Dependencies: [Identified|Partial|Missing]
+- **Resource Planning**: [REALISTIC|OPTIMISTIC|UNREALISTIC|MISSING]
+  - Team requirements: [Specific|General|Missing]
+  - Timeline feasibility: [Realistic|Tight|Impossible]
+- **Risk Assessment**: [COMPREHENSIVE|BASIC|MINIMAL|MISSING]
+  - Risk identification: [Thorough|Basic|None]
+  - Mitigation plans: [Detailed|General|Missing]
+
+### 🔗 INTEGRATION VALIDATION
+- **Document Consistency**: [EXCELLENT|GOOD|POOR] - Cross-document alignment
+- **Cross-References**: [WORKING|PARTIAL|BROKEN] - Link integrity
+- **Navigation**: [COMPLETE|PARTIAL|MISSING] - Document structure
+- **Terminology**: [CONSISTENT|MOSTLY|INCONSISTENT] - Language consistency
+
+### ⚠️ ISSUES IDENTIFIED
+
+#### Critical Issues (Must Fix)
+[List critical issues that prevent workflow success]
+
+#### Warning Issues (Recommended to Address)
+[List quality issues that should be improved]
+
+### ✅ FEASIBILITY ASSESSMENT
+- **Technical Approach**: [SOUND|QUESTIONABLE|FLAWED]
+- **Timeline Realism**: [REALISTIC|OPTIMISTIC|UNREALISTIC]
+- **Resource Requirements**: [ACHIEVABLE|CHALLENGING|IMPOSSIBLE]
+- **Recommendation Practicality**: [ACTIONABLE|GENERAL|IMPRACTICAL]
+
+## Workflow Readiness
+- **Ready for Implementation**: [YES|WITH_CONDITIONS|NO]
+- **Quality Level**: [PRODUCTION_READY|NEEDS_IMPROVEMENT|REQUIRES_REWORK]
+- **Confidence Score**: [score/10]
+
+## Recommendations
+[Specific actions to improve workflow quality]
+
+## Next Steps
+[Immediate actions required before proceeding]
+```
+
+### Quick Status Check
+```markdown
+## Quick Workflow Status
+
+**Overall Result**: [SUCCESS|PARTIAL|FAILED]
+
+**Document Quality**:
+- Discovery: [EXCELLENT|GOOD|FAIR|POOR]
+- PRD: [EXCELLENT|GOOD|FAIR|POOR]
+- Plan: [EXCELLENT|GOOD|FAIR|POOR]
+
+**Critical Issues**: [count] (must address before implementation)
+**Quality Warnings**: [count] (recommended improvements)
+
+**Implementation Ready**: [YES|NO]
+```
+
+## Integration with Workflow System:
+- Receive workflow completion notification from coordinators
+- Validate all workflow documents against quality standards
+- Provide detailed quality assessment and improvement recommendations
+- Report validation results for coordinator decision-making
+
+Your role is to ensure Claudio workflow documents meet high quality standards and provide actionable, realistic guidance for project implementation. Focus on content quality, not file installation validation.

--- a/.claude/commands/claudio/claudio.md
+++ b/.claude/commands/claudio/claudio.md
@@ -5,14 +5,21 @@ argument-hint: "<target_project_path> [--implement]"
 
 Comprehensive project analysis and planning system that orchestrates discovery, requirements, planning, and task organization for any codebase. Creates a complete `.claudio/` folder with full project roadmap through parallel workflow execution.
 
+**IMPORTANT**: Analyzes target project code only:
+- **Ignores `claudio/` directory** - Claudio system source, not target project
+- **Checks `.claudio/` for existing install** - Preserves status, doesn't analyze as code
+- **Focuses on actual project** - Technology stack, architecture, capabilities
+
 **Standard Workflow** (Recommended):
-- Analysis and planning only: `/claudio <project_path>`
+- Analysis and planning with validation: `/claudio <project_path>` → workflow → **validate completion**
 - Separate implementation: `/claudio:implement <project_path>`
 
 **Optional Implementation Integration**:
 - Include implementation execution: `/claudio <project_path> --implement`
 
-Use the claudio:claudio-coordinator subagent to orchestrate the complete analysis workflow with parallel phase execution. The `--implement` flag optionally includes implementation execution as the final phase.
+Use the claudio:claudio-coordinator subagent to orchestrate the complete analysis workflow with parallel phase execution and automatic validation. The system automatically excludes Claudio system directories to focus on actual project analysis. 
+
+**Workflow includes automatic final validation** to ensure all documents and project structure are properly generated. The `--implement` flag optionally includes implementation execution as the final phase.
 
 **Reference**: Uses `.claude/agents/claudio/prompts/claudio/claude.md` for comprehensive workflow templates and execution patterns.
 

--- a/.claude/commands/claudio/generate-test-commands.md
+++ b/.claude/commands/claudio/generate-test-commands.md
@@ -1,0 +1,40 @@
+---
+description: "Generate project-specific test commands based on discovery analysis"
+argument-hint: "<target_project_path>"
+---
+
+**SYSTEM COMMAND** - Automatically called during install/upgrade workflows. Stays in Claudio system, only generated commands are installed in user projects.
+
+Generate custom test commands (`/claudio:test` and `/claudio:test-g`) with their sub-agents and extended context based on the target project's discovery analysis. Creates project-specific testing capabilities that understand the project's test framework, structure, and requirements.
+
+**Generated Commands (installed in target project):**
+- `/claudio:test` - Runs project test suite with intelligent summary and optional --fix flag
+- `/claudio:test-g` - Gemini-integrated testing with read-only analysis and task generation
+
+**Automatic Integration:**
+This command is automatically called during:
+- `/claudio:install /path/to/project`
+- `/claudio:install commands /path/to/project` 
+- `/claudio:claudio /path/to/project`
+- `/claudio:upgrade /path/to/project`
+
+**Requirements:**
+- Target project must have discovery analysis completed (discovery.md)
+- For generated `/claudio:test-g`: Requires gemini-cli access and appropriate API configuration
+
+**Process:**
+1. Analyze project discovery documents to understand testing framework
+2. Generate project-specific test command implementations  
+3. Create specialized sub-agents for test execution and analysis
+4. Generate extended context based on project's testing patterns
+5. Install generated commands in target project's `.claudio/` structure
+
+**Command Distribution:**
+- **This system command**: Remains in Claudio system directory only
+- **Generated test commands**: Installed in `<target_project>/.claudio/commands/claudio/`
+- **Generated sub-agents**: Installed in `<target_project>/.claudio/agents/claudio/`
+- **Generated context**: Installed in `<target_project>/.claudio/agents/claudio/prompts/`
+
+Use the claudio:test-command-generator subagent to orchestrate discovery analysis, command generation, and installation process.
+
+**Validator Note**: Install validators should expect `/claudio:test` and `/claudio:test-g` commands in user project installations, but NOT expect `generate-test-commands` in user directories.

--- a/.claude/commands/claudio/install.md
+++ b/.claude/commands/claudio/install.md
@@ -3,13 +3,24 @@ description: "Install Claudio system components with flexible path support and c
 argument-hint: "[commands] [user|<path>]"
 ---
 
-Install Claudio system components through intelligent project localization to different target locations with flexible installation modes. Components are customized based on project discovery rather than directly copied.
+Install complete Claudio system through intelligent project localization to different target locations with flexible installation modes. All components are customized based on project discovery rather than directly copied.
 
-**Syntax:**
-- `/install` - defaults to project mode, full workflow
-- `/install commands` - defaults to project mode, commands only
-- `/install commands user` - user mode, commands only
-- `/install /path/to/code` - path mode, full workflow
-- `/install commands /path/to/code` - path mode, commands only
+**IMPORTANT**: "Commands" installs complete functional system:
+- Commands files (`commands/claudio/`)
+- Required sub-agents (`agents/claudio/`) 
+- Extended context documents (`agents/claudio/prompts/`)
 
-Use the claudio:install-coordinator subagent to orchestrate the installation process with project discovery, component localization, and parallel validation.
+**Installation Workflows with Validation:**
+- `/install` - Full workflow → validate workflow → install → validate installation
+- `/install commands` - Discovery → validate discovery → install complete system → validate installation  
+- `/install commands user` - Install generic templates → validate installation
+- `/install /path/to/code` - Full workflow → validate workflow → install → validate installation
+- `/install commands /path/to/code` - Discovery → validate discovery → install complete system → validate installation
+
+Use the claudio:install-coordinator subagent to orchestrate the complete installation process with:
+- Project discovery and analysis
+- Complete system component generation (commands + agents + prompts)
+- Multi-point validation (workflow validation + installation validation)
+- Comprehensive quality assurance and reporting
+
+**All installations include automatic validation** to ensure complete functional system is properly installed.

--- a/.claude/commands/claudio/new-command.md
+++ b/.claude/commands/claudio/new-command.md
@@ -1,0 +1,81 @@
+---
+description: "Generate custom commands with sub-agents and extended context from research sources"
+argument-hint: "<name> \"<purpose>\" <source> [--claudio \"<workflow_position>\"]"
+---
+
+Generate complete custom command systems (command + sub-agent + extended context) based on user specifications and research sources. Creates professional-quality commands that follow Claudio patterns and integrate seamlessly with existing workflows.
+
+**Command Structure:**
+`/new-command <name> "<purpose>" <source> [--claudio "<workflow_position>"]`
+
+**Parameters:**
+- **name**: Command name (alphanumeric, hyphens allowed)
+- **purpose**: Brief description of what the command does
+- **source**: URL or local file path for research context
+- **--claudio**: Optional workflow integration position
+
+**Examples:**
+
+**User Command (standalone):**
+```bash
+/new-command mycommand "analyzes project dependencies" https://docs.npmjs.com/cli/v8/commands/npm-audit
+```
+
+**Workflow Integration:**
+```bash
+/new-command security-scan "performs security analysis" ./security-guide.md --claudio "after discovery workflow"
+```
+
+**Source Types:**
+- **URLs**: Automatically researched via `/claudio:research` command
+- **Local Files**: Analyzed and integrated as extended context
+- **Documentation**: README files, API docs, guides, specifications
+
+**Generated Components:**
+
+1. **Command File**: `commands/claudio/{name}.md`
+   - Proper frontmatter and description
+   - Usage examples and integration guidance
+   - Reference to specialized sub-agent
+
+2. **Sub-Agent**: `agents/claudio/{name}-executor.md`
+   - Specialized agent for command execution
+   - Tools and capabilities based on research
+   - Error handling and validation
+
+3. **Extended Context**: `agents/claudio/prompts/{name}/claude.md`
+   - Comprehensive context from research source
+   - Best practices and implementation patterns
+   - Framework-specific guidance
+
+**Workflow Integration Options:**
+- `"after discovery workflow"` - Runs after project discovery
+- `"after prd workflow"` - Runs after requirements generation
+- `"after plan workflow"` - Runs after implementation planning
+- `"before task workflow"` - Runs before task breakdown
+- `"parallel with [phase]"` - Runs concurrently with specified phase
+
+**Installation:**
+- **User Commands**: Installed in current project only
+- **Workflow Commands**: Integrated into Claudio system workflows
+- **Validation**: Automatic validation of generated command structure
+
+**Quality Assurance:**
+- Research-driven context generation
+- Template-based consistent structure
+- Integration validation and testing
+- Following established Claudio patterns
+
+Use the claudio:new-command-generator subagent to orchestrate research analysis, template generation, and command installation process.
+
+**Prerequisites:**
+- For URL sources: Internet access for research
+- For workflow integration: Proper understanding of Claudio workflow phases
+- Write permissions for target installation directory
+
+**Validation:**
+All generated commands undergo automatic validation to ensure:
+- Proper file structure and formatting
+- Correct sub-agent integration
+- Valid extended context references
+- Workflow integration compatibility (if applicable)

--- a/.claude/commands/claudio/test-review.md
+++ b/.claude/commands/claudio/test-review.md
@@ -3,4 +3,4 @@ description: "review project testing patterns"
 argument-hint: ""
 ---
 
-Please analyze the current project testing framework and tools, Use the claudio:test-review subagent to perform this analysis.
+Please analyze the current project testing framework and tools, Use the claudio:test-review subagent to analyze testing frameworks and tools configuration.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The default workflow combines **discovery and planning** into a unified process 
 
 Claudio employs specialized AI agents that orchestrate different aspects of project analysis:
 
+### Core Workflow Agents
 - **Discovery Agent**: Analyzes project structure, technology stack, and existing capabilities
 - **PRD Agent**: Transforms discovery findings into clear business requirements and success criteria
 - **Planning Agent**: Creates phased implementation roadmaps with time estimates and dependencies
@@ -30,7 +31,23 @@ Claudio employs specialized AI agents that orchestrate different aspects of proj
 - **Research Agent**: Conducts topic-specific research and creates expert knowledge bases
 - **Implementation Agent**: Executes plans through coordinated task processing
 
-Each agent is self-contained but works cooperatively, referencing other agents' outputs to create comprehensive, integrated project analysis and implementation plans. When installed in project/path modes, agents are automatically localized for the specific project context.
+### Generation & Customization Agents
+- **Test Command Generator**: Creates project-specific test commands based on framework detection
+- **New Command Generator**: Generates custom commands from research sources with workflow integration
+- **Newprompt Agent Creator**: Creates comprehensive agent prompts following Claudio conventions
+
+### Quality Assurance Validators
+- **Discovery Validator**: Ensures discovery document quality and analysis depth
+- **Workflow Validator**: Validates complete workflow output and document completeness
+- **Install Validator**: Verifies installation completeness and functionality
+- **New Command Validator**: Validates custom command structure and integration
+
+### System Management Agents
+- **Install Coordinator**: Manages Claudio installation with namespace support and localization
+- **Upgrade Orchestrator**: Handles safe upgrades with backup, rollback, and re-localization
+- **Code Quality Analyzer**: Analyzes code quality with comprehensive reporting
+
+Each agent is self-contained but works cooperatively, referencing other agents' outputs to create comprehensive, integrated project analysis and implementation plans. When installed in project/path modes, agents are automatically localized for the specific project context through discovery-based customization.
 
 ## Requirements
 
@@ -127,8 +144,12 @@ This will create a comprehensive `.claudio/` folder in your target project with:
 2. **Start Claude with access**: `claude --add-dir /path/to/your/project`
 3. **Discovery & Planning**: `/claudio:claudio /path/to/your/project` (combines project analysis and implementation planning)
 4. **Review the plans**: Check the generated `.claudio/` folder in your project
-5. **Optional Implementation**: `/claudio:implement /path/to/your/project` (when ready to execute)
-6. **Keep system updated**: `/claudio:upgrade --check` periodically
+5. **Test your project**: Use auto-generated `/claudio:test` command for project-specific testing
+6. **Create custom tools**: `/claudio:new-command tool-name "purpose" source-url` for project-specific commands
+7. **Optional Implementation**: `/claudio:implement /path/to/your/project` (when ready to execute)
+8. **Keep system updated**: `/claudio:upgrade --check` periodically
+
+**Quality Assurance**: All outputs are automatically validated for completeness and quality through integrated validation loops.
 
 ### Team/Organization Setup
 1. **Install localized system**: `/claudio:install /path/to/team/project` (runs discovery and localizes components)
@@ -216,16 +237,20 @@ project/.claudio/
 | Command | Purpose | Example | Localization |
 |---------|---------|---------|-------------|
 | `/claudio:implement` | Execute implementation plans** | `/claudio:implement ../my-project` | Project-specific execution with localized contexts |
+| `/claudio:test`**** | Run project tests with analysis | `/claudio:test` or `/claudio:test --fix` | Auto-generated for each project's test framework |
+| `/claudio:test-g`**** | Gemini-integrated testing | `/claudio:test-g` | Project-specific test analysis with AI assistance |
 
 ### System Management
 | Command | Purpose | Example | Localization |
 |---------|---------|---------|-------------|
 | `/claudio:install` | Install Claudio components | `/claudio:install` or `/claudio:install commands user` | Project/path modes: localization via discovery; User mode: direct template copying |
 | `/claudio:upgrade` | Upgrade with re-localization | `/claudio:upgrade` or `/claudio:upgrade /path/to/project` | Re-localizes components based on current project state |
+| `/claudio:generate-test-commands`***** | Generate project test commands | System command - auto-called during install/upgrade | Creates project-specific test commands based on discovery |
 
 ### Utilities
 | Command | Purpose | Example | Localization |
 |---------|---------|---------|-------------|
+| `/claudio:new-command` | Generate custom commands from research | `/claudio:new-command my-tool "analyzes dependencies" https://docs.npmjs.com` | Research-driven command generation with workflow integration |
 | `/claudio:newprompt` | Create new agent prompts | `/claudio:newprompt security-review "vulnerability analysis" standard` | Template-based with project integration patterns |
 | `/claudio:test-review` | Analyze testing patterns and frameworks | `/claudio:test-review` | Technology stack-specific testing analysis |
 | `/claudio:gcms` | Generate conventional git commit messages | `/claudio:gcms` | Project convention-aware commit messages |
@@ -236,6 +261,162 @@ project/.claudio/
 **Implementation command is optional and invoked separately when ready to execute plans
 
 ***Optional command - see [Optional Commands](#optional-commands) for installation
+
+****Auto-generated project-specific test commands installed during `/claudio:install` or `/claudio:upgrade`
+
+*****System command that remains in Claudio source, automatically called during installation/upgrade workflows
+
+## Validation System
+
+Claudio includes a comprehensive quality assurance framework with specialized validators that ensure system reliability and output quality across all workflows.
+
+### Validation Components
+
+#### Discovery Validator
+- **Purpose**: Validates discovery document quality and analysis depth
+- **Checks**: Technology detection, architecture analysis, dependency mapping, improvement recommendations
+- **Success Criteria**: Minimum sections present, technical depth achieved, actionable insights provided
+- **Auto-runs**: After discovery phase in workflows
+
+#### Workflow Validator  
+- **Purpose**: Validates complete Claudio workflow output quality
+- **Checks**: Document completeness, phase structure, task breakdown, status tracking setup
+- **Success Criteria**: All required documents present, proper linking between phases, executable task contexts
+- **Auto-runs**: After `/claudio:claudio` workflow completion
+
+#### Install Validator
+- **Purpose**: Validates installation completeness and functionality
+- **Checks**: Command installation, agent setup, directory structure, file permissions
+- **Success Criteria**: All components installed, proper namespacing, test commands generated
+- **Auto-runs**: After `/claudio:install` operations
+
+#### New Command Validator
+- **Purpose**: Validates custom command generation quality
+- **Checks**: Command structure, sub-agent integration, context references, workflow compatibility
+- **Success Criteria**: Proper formatting, valid integration points, executable command structure
+- **Auto-runs**: After `/claudio:new-command` generation
+
+### Validation Integration
+
+Validators are integrated into workflows automatically:
+- **Discovery workflows**: Run discovery validator after analysis
+- **Installation workflows**: Run install validator after setup
+- **Custom command creation**: Run command validator after generation
+- **Complete workflows**: Run workflow validator at completion
+
+### Validation Reports
+
+Each validator generates detailed reports including:
+- **Pass/Fail Status**: Clear success or failure indication
+- **Detailed Findings**: Specific issues or confirmations
+- **Recommendations**: Actionable improvement suggestions
+- **Quality Metrics**: Quantitative assessment of output quality
+
+## Custom Command Generation
+
+Claudio enables you to create custom commands tailored to your specific needs through research-driven generation.
+
+### Using `/claudio:new-command`
+
+Generate complete command systems (command + sub-agent + context) from research sources:
+
+```bash
+# Create from URL research
+/claudio:new-command dependency-analyzer "analyzes project dependencies" https://docs.npmjs.com/cli/v8/commands/npm-audit
+
+# Create from local documentation
+/claudio:new-command api-validator "validates API endpoints" ./api-spec.md
+
+# Integrate with Claudio workflow
+/claudio:new-command security-scan "performs security analysis" https://owasp.org/www-project-top-ten/ --claudio "after discovery workflow"
+```
+
+### Generated Components
+
+Each custom command creates:
+
+1. **Command File** (`commands/claudio/{name}.md`)
+   - Usage documentation and examples
+   - Parameter definitions
+   - Integration instructions
+
+2. **Sub-Agent** (`agents/claudio/{name}-executor.md`)
+   - Specialized execution logic
+   - Tool selection and capabilities
+   - Error handling
+
+3. **Extended Context** (`agents/claudio/prompts/{name}/claude.md`)
+   - Research-based knowledge
+   - Best practices and patterns
+   - Framework-specific guidance
+
+### Workflow Integration Options
+
+Custom commands can integrate into Claudio workflows:
+- `"after discovery workflow"` - Runs after project analysis
+- `"after prd workflow"` - Runs after requirements generation
+- `"after plan workflow"` - Runs after implementation planning
+- `"before task workflow"` - Runs before task breakdown
+- `"parallel with [phase]"` - Runs concurrently with specified phase
+
+### Quality Assurance
+
+All generated commands undergo automatic validation:
+- Structure and formatting verification
+- Sub-agent integration testing
+- Context reference validation
+- Workflow compatibility checking
+
+## Project-Specific Testing
+
+Claudio automatically generates customized test commands for each project based on its discovered testing framework and patterns.
+
+### Auto-Generated Test Commands
+
+During installation or upgrade, Claudio analyzes your project and creates:
+
+#### `/claudio:test` - Intelligent Test Runner
+- **Features**: 
+  - Runs your project's test suite with framework detection
+  - Provides intelligent summary and analysis
+  - Optional `--fix` flag for auto-remediation
+  - Framework-specific optimizations
+- **Example**: `/claudio:test` or `/claudio:test --fix`
+
+#### `/claudio:test-g` - Gemini-Enhanced Testing
+- **Features**:
+  - AI-assisted test analysis and recommendations
+  - Read-only analysis with task generation
+  - Advanced pattern detection
+  - Test coverage insights
+- **Requirements**: Gemini CLI access and API configuration
+- **Example**: `/claudio:test-g`
+
+### Framework Detection
+
+Test commands are customized for detected frameworks:
+- **JavaScript/TypeScript**: Jest, Mocha, Vitest, Karma
+- **Python**: pytest, unittest, nose2
+- **Ruby**: RSpec, Minitest
+- **Go**: go test, testify
+- **Rust**: cargo test
+- **Java**: JUnit, TestNG
+- **Other frameworks**: Automatically detected from project structure
+
+### Installation Process
+
+Test commands are automatically generated during:
+- `/claudio:install` - Full system installation
+- `/claudio:install commands` - Commands-only installation
+- `/claudio:upgrade` - System upgrades
+- `/claudio:claudio` - Complete workflow execution
+
+The generation process:
+1. Analyzes project discovery document
+2. Detects testing frameworks and patterns
+3. Generates customized command implementations
+4. Creates specialized sub-agents
+5. Installs in project's `.claude/` directory
 
 ## Installation and System Management
 
@@ -519,7 +700,14 @@ claude --add-dir ../my-react-app
 /claudio:claudio ../my-react-app
 /claudio:implement ../my-react-app  # When ready to execute
 
-# 4. Keep system updated
+# 4. Test your project with auto-generated commands
+/claudio:test                        # Run tests with intelligent analysis
+/claudio:test-g                      # Enhanced testing with Gemini
+
+# 5. Create custom commands as needed
+/claudio:new-command metrics "track performance" ./perf-guide.md
+
+# 6. Keep system updated
 /claudio:upgrade --check
 ```
 
@@ -547,6 +735,12 @@ claude
 /claudio:prd feature real-time-chat   # Create requirements doc with domain awareness
 /claudio:test-review                  # Analyze testing setup with framework-specific insights
 /claudio:gcms                        # Generate commit messages following project conventions
+
+# New command generation and testing
+/claudio:new-command linter "code style checker" https://eslint.org/docs  # Create custom command
+/claudio:test                        # Run project tests with intelligent analysis
+/claudio:test --fix                  # Run tests with auto-remediation
+/claudio:test-g                      # Gemini-enhanced test analysis
 ```
 
 ### System Management
@@ -629,7 +823,9 @@ claudio/
 │   │   ├── research.md   # Topic research
 │   │   ├── documentation.md # Documentation generation
 │   │   ├── design.md     # UX/UI analysis
+│   │   ├── new-command.md # Custom command generation
 │   │   ├── newprompt.md  # Agent creation system
+│   │   ├── generate-test-commands.md # Test command generator (system)
 │   │   ├── install.md    # Installation management
 │   │   ├── upgrade.md    # Upgrade management
 │   │   ├── test-review.md # Testing analysis
@@ -646,6 +842,8 @@ claudio/
 │       ├── install-coordinator.md # Installation management
 │       ├── upgrade-orchestrator.md # Upgrade coordination
 │       ├── documentation-coordinator.md # Documentation coordination
+│       ├── new-command-generator.md # Custom command generation
+│       ├── test-command-generator.md # Test command generation
 │       ├── newprompt-coordinator.md # Agent creation
 │       ├── code-quality-analyzer.md # Quality assessment
 │       ├── design-analyzer.md # UX/UI analysis
@@ -657,6 +855,10 @@ claudio/
 │       ├── security-diagram-generator.md # Security Mermaid diagrams
 │       ├── vulnerability-assessment-specialist.md # Vulnerability analysis
 │       ├── security-architecture-analyst.md # Security architecture review
+│       ├── discovery-validator.md # Discovery validation
+│       ├── workflow-validator.md # Workflow validation
+│       ├── install-validator.md # Installation validation
+│       ├── new-command-validator.md # Command validation
 │       └── prompts/      # Extended agent contexts
 │           ├── claudio/  # Master orchestration context
 │           ├── discovery/ # Project analysis context
@@ -667,6 +869,9 @@ claudio/
 │           ├── research/ # Research context
 │           ├── documentation/ # Documentation context
 │           ├── design/   # Design analysis context
+│           ├── new-command/ # Custom command templates
+│           ├── test-generation/ # Test command templates
+│           ├── validation/ # Validation templates
 │           ├── newprompt/ # Agent creation context
 │           ├── install/  # Installation context
 │           ├── upgrade/  # Upgrade context
@@ -715,7 +920,43 @@ your-project/
 
 ### Contributing to Claudio
 
-Claudio includes a comprehensive test suite to validate all workflows and ensure system reliability across different project types and complexity levels.
+Claudio includes a comprehensive test suite with validation loops and template systems to ensure quality and consistency across all components.
+
+#### Validation-Driven Development
+
+All Claudio components undergo automatic validation:
+- **Discovery Documents**: Validated for completeness and depth
+- **Generated Commands**: Validated for structure and integration
+- **Workflow Outputs**: Validated for document quality
+- **Installations**: Validated for completeness and functionality
+
+#### Template System
+
+Claudio uses standardized templates for consistency:
+
+##### Command Templates
+- **Structure**: Frontmatter, description, usage, parameters
+- **Integration**: Sub-agent references, workflow hooks
+- **Validation**: Automatic structure verification
+
+##### Agent Templates  
+- **Components**: Purpose, responsibilities, tools, methodology
+- **Patterns**: Consistent naming, error handling, output formats
+- **Localization**: Project-specific customization points
+
+##### Context Templates
+- **Organization**: Structured knowledge sections
+- **References**: Cross-agent integration points
+- **Extensions**: Research-based content additions
+
+#### Validation Loops
+
+Development workflow includes integrated validation:
+1. **Pre-generation**: Validate inputs and requirements
+2. **Generation**: Apply templates with consistency checks
+3. **Post-generation**: Validate output structure and quality
+4. **Integration**: Validate workflow compatibility
+5. **Installation**: Validate deployment completeness
 
 #### Test Suite Structure
 
@@ -818,6 +1059,44 @@ When adding new Claudio features:
 
 The test projects are **generated examples** designed specifically for validation - they are not live projects but carefully crafted scenarios that exercise all Claudio capabilities.
 
+#### Creating New Validators
+
+To add a new validator:
+
+1. **Create Validator Agent**: `agents/claudio/{name}-validator.md`
+   - Define validation criteria and success metrics
+   - Specify tools needed for validation
+   - Include detailed reporting template
+
+2. **Integration Points**: Update workflows to call validator
+   - Add to relevant command workflows
+   - Include in installation/upgrade processes
+   - Ensure proper error handling
+
+3. **Testing**: Add test cases for validator
+   - Success scenarios with valid inputs
+   - Failure scenarios with invalid inputs
+   - Edge cases and boundary conditions
+
+#### Creating New Generators
+
+To add a new generator:
+
+1. **Create Generator Agent**: `agents/claudio/{name}-generator.md`
+   - Define generation logic and templates
+   - Specify research/discovery requirements
+   - Include localization patterns
+
+2. **Template Creation**: Add templates in `prompts/{category}/`
+   - Standardized structure and formatting
+   - Placeholders for customization
+   - Validation hooks
+
+3. **Command Integration**: Create command in `commands/claudio/`
+   - User-facing interface
+   - Parameter validation
+   - Generator agent invocation
+
 ## Benefits
 
 - **Instant Project Understanding**: Get comprehensive discovery and analysis of any codebase
@@ -828,8 +1107,12 @@ The test projects are **generated examples** designed specifically for validatio
 - **Progress Visibility**: Track work at project, phase, and task levels
 - **Team Collaboration**: Shared project-localized contexts enable consistent development approach
 - **Security Analysis**: Comprehensive STRIDE-based security review with technology-specific threat modeling
-- **Quality Assurance**: Built-in review and testing requirements tailored to your project
+- **Quality Assurance**: Built-in validation system ensures output quality and consistency
 - **Multi-Mode Flexibility**: Use globally for multiple projects or install project-specific versions
+- **Custom Command Generation**: Create tailored commands from research sources with workflow integration
+- **Automated Testing**: Project-specific test commands generated based on framework detection
+- **Validation Loops**: Integrated quality checks throughout all workflows
+- **Template System**: Consistent structure across all generated components
 
 ## Getting Help
 

--- a/changelog/2025-08-08.md
+++ b/changelog/2025-08-08.md
@@ -196,3 +196,19 @@ This update represents a fundamental evolution of Claudio from a project analysi
 - Development best practices updated with validation-driven approach
 
 This represents the most comprehensive single-day enhancement in Claudio's development history, establishing it as a complete development ecosystem rather than just an analysis tool.
+
+## Sub-Agent Pattern Validation
+### Command Pattern Compliance Validation
+- **Validation Completed**: All 18 command files validated for Claude Code sub-agent invocation patterns
+- **Pattern Correction**: Fixed `test-review.md` command sub-agent invocation to include proper action description
+  - **Before**: `"Use the claudio:test-review subagent to perform this analysis."`
+  - **After**: `"Use the claudio:test-review subagent to analyze testing frameworks and tools configuration."`
+- **Pattern Compliance**: All commands now follow correct `"Use the claudio:agent-name subagent to [action description]"` pattern
+- **Namespace Consistency**: All sub-agent references use proper `claudio:` namespace prefix
+- **Agent-Command Alignment**: Verified all referenced sub-agents exist and are properly aligned with command invocations
+
+### Documentation Standards Achievement
+- **Claude Code Compliance**: All commands now properly follow Claude Code sub-agent documentation patterns
+- **Automatic Delegation**: Commands structured for intelligent sub-agent selection by Claude Code
+- **Action-Oriented Descriptions**: All sub-agent invocations include clear, specific action descriptions
+- **Quality Assurance**: Pattern validation ensures reliable agent delegation and execution

--- a/changelog/2025-08-08.md
+++ b/changelog/2025-08-08.md
@@ -1,0 +1,198 @@
+# Changelog - August 8, 2025
+
+## Overview
+Major system enhancement transforming Claudio from a basic project analysis tool into a comprehensive development ecosystem. Added complete validation framework, custom command generation system, auto-generated project-specific testing, and extensive documentation overhaul. This represents the most significant feature expansion in Claudio's evolution.
+
+## New Validation System
+### Comprehensive Quality Assurance Framework
+- **Discovery Validator** (`discovery-validator.md`): Validates discovery document quality, technical depth, and analysis completeness
+- **Workflow Validator** (`workflow-validator.md`): Ensures complete workflow outputs with proper document structure and task contexts  
+- **Install Validator** (`install-validator.md`): Verifies installation completeness, file structure, and functionality
+- **New Command Validator** (`new-command-validator.md`): Validates custom command structure, integration points, and quality
+
+### Validation Integration
+- **Automatic Execution**: Validators run automatically during relevant workflows
+- **Quality Reports**: Detailed pass/fail reports with specific findings and recommendations
+- **Success Criteria**: Explicit validation criteria with quantitative quality metrics
+- **Error Handling**: Graceful failure handling with actionable feedback
+
+## Command Generation System
+### Custom Command Creation (`/claudio:new-command`)
+- **Research-Driven**: Generate commands from URL sources or local documentation
+- **Complete Component Creation**: Automatically creates command file, sub-agent, and extended context
+- **Workflow Integration**: Optional integration into Claudio workflows with positioning options
+- **Template-Based**: Consistent structure following established Claudio patterns
+- **Quality Validation**: Automatic validation of generated command structure
+
+### System Command Generator (`/claudio:generate-test-commands`)
+- **Auto-Called**: System command that runs during install/upgrade workflows
+- **Project-Specific**: Analyzes discovery documents to create tailored test commands
+- **Framework Detection**: Supports Jest, pytest, RSpec, go test, cargo test, and more
+- **Localized Installation**: Generated commands installed in target project's `.claudio/` structure
+
+## Auto-Generated Testing System
+### Project-Specific Test Commands
+- **`/claudio:test`**: Intelligent test runner with framework detection and optional `--fix` flag
+- **`/claudio:test-g`**: Gemini-integrated testing with AI-assisted analysis and recommendations
+- **Framework Customization**: Commands automatically adapt to detected testing frameworks
+- **Installation Integration**: Test commands generated during every install/upgrade operation
+
+### Testing Capabilities
+- **Smart Analysis**: Intelligent test result summary and failure analysis
+- **Auto-Remediation**: `--fix` flag for automatic issue resolution
+- **Coverage Insights**: Test coverage analysis and recommendations
+- **Framework Agnostic**: Works with JavaScript, Python, Ruby, Go, Rust, Java frameworks
+
+## Documentation Overhaul
+### README.md Major Updates (295+ lines added)
+- **New Sections Added**:
+  - Validation System documentation with detailed component descriptions
+  - Custom Command Generation with usage examples and workflow integration
+  - Project-Specific Testing with framework detection and auto-generation
+  - Enhanced Architecture section with new agent categories
+  - Expanded Development section with validation loops and template system
+
+### Documentation Enhancements
+- **Command Table Updates**: All new commands documented with localization details
+- **Usage Examples**: Updated all workflow examples to include new features
+- **Project Structure**: Complete documentation of new agents and prompt directories
+- **Benefits Section**: Enhanced with quality assurance and customization capabilities
+
+## Agent Infrastructure Expansion
+### New Generation & Customization Agents
+- **New Command Generator** (`new-command-generator.md`): Orchestrates custom command creation from research
+- **Test Command Generator** (`test-command-generator.md`): Creates project-specific test commands
+- **Newprompt Agent Creator**: Enhanced agent prompt creation following Claudio conventions
+
+### Enhanced System Management
+- **Install Coordinator** (enhanced): Added validation integration and test command generation
+- **Upgrade Orchestrator** (enhanced): Re-localization with validation and test command updates
+- **Discovery Orchestrator** (enhanced): Integration with validation framework
+
+## Template System Implementation
+### Standardized Templates
+- **Command Templates**: Consistent structure with frontmatter, usage, and integration patterns
+- **Agent Templates**: Standardized components with purpose, responsibilities, and methodology
+- **Context Templates**: Organized knowledge sections with cross-agent references
+- **Validation Templates**: Consistent reporting formats and success criteria
+
+### Template Directories
+- **`prompts/new-command/`**: Custom command generation templates
+- **`prompts/test-generation/`**: Test command generation templates  
+- **`prompts/validation/`**: Validation criteria and reporting templates
+
+## Development Workflow Enhancement
+### Validation-Driven Development
+- **Pre-generation Validation**: Input and requirement validation before generation
+- **Generation Consistency**: Template application with automatic consistency checks
+- **Post-generation Quality**: Output structure and quality validation
+- **Integration Verification**: Workflow compatibility validation
+- **Installation Completeness**: Deployment and functionality validation
+
+### Enhanced CI/CD Integration
+- **Test Suite Updates**: Integration with new validation and generation systems
+- **Quality Gates**: Validation checkpoints throughout development workflow
+- **Template Consistency**: Automated verification of component structure
+- **Error Detection**: Early detection of integration and structure issues
+
+## User Experience Impact
+### Quality Assurance
+- **Automatic Validation**: All outputs validated for completeness and quality
+- **Consistent Structure**: Template-based generation ensures uniformity
+- **Error Prevention**: Early detection and prevention of common issues
+- **Quality Metrics**: Quantitative assessment of output quality
+
+### Customization Capabilities
+- **Custom Commands**: Create project-specific tools from any research source
+- **Workflow Integration**: Custom commands can integrate into Claudio workflows
+- **Auto-Generated Testing**: Project-specific test automation without manual configuration
+- **Framework Adaptation**: All components automatically adapt to project technology stack
+
+### Developer Productivity
+- **Reduced Configuration**: Auto-generated test commands eliminate manual setup
+- **Research-Driven Tools**: Create custom commands from documentation and guides
+- **Quality Feedback**: Immediate validation feedback during development
+- **Consistent Patterns**: Template system ensures predictable component structure
+
+## Technical Implementation Details
+### Modified Files (10 files, 567 lines changed)
+1. **README.md** (295+ lines): Comprehensive documentation of all new features
+2. **claudio-coordinator.md** (41 lines): Integration with validation system
+3. **claudio-discovery-orchestrator.md** (35 lines): Validation integration
+4. **install-coordinator.md** (92 lines): Test command generation and validation
+5. **install-validator.md** (17 lines): Enhanced validation criteria
+6. **prompts/claudio/claude.md** (25 lines): Master orchestration updates
+7. **upgrade-orchestrator.md** (2 lines): Validation integration
+8. **claudio.md** (11 lines): Command updates for new features
+9. **install.md** (27 lines): Installation process enhancements
+10. **promptlog.md** (90 lines): Development session documentation
+
+### New Files Added (10 files)
+#### New Validators
+- `discovery-validator.md`: Discovery quality validation
+- `workflow-validator.md`: Complete workflow validation  
+- `install-validator.md`: Installation completeness validation
+- `new-command-validator.md`: Custom command structure validation
+
+#### New Generators
+- `new-command-generator.md`: Custom command generation orchestration
+- `test-command-generator.md`: Project-specific test command creation
+
+#### New Commands
+- `new-command.md`: User-facing custom command creation
+- `generate-test-commands.md`: System test command generator
+
+#### New Template Directories
+- `prompts/new-command/`: Custom command templates
+- `prompts/test-generation/`: Test generation templates
+- `prompts/validation/`: Validation templates and criteria
+
+## System Evolution Significance
+This update represents a fundamental evolution of Claudio from a project analysis tool to a complete development ecosystem. The addition of validation loops ensures quality and consistency, while the command generation system enables unlimited customization. Auto-generated testing provides immediate productivity benefits for any project type.
+
+### Before This Update
+- Basic project analysis and planning
+- Manual command creation
+- Generic workflows without quality assurance
+- Limited customization options
+
+### After This Update  
+- Comprehensive quality assurance framework
+- Research-driven custom command generation
+- Auto-generated project-specific testing
+- Template-based consistency across all components
+- Validation loops integrated throughout all workflows
+- Complete development ecosystem with customization capabilities
+
+## Next Steps Identified
+### Immediate Enhancements
+- Additional framework detection patterns for test command generation
+- More validation criteria for specialized project types
+- Enhanced error handling and recovery mechanisms
+- Performance optimization for large project analysis
+
+### Future Development
+- Visual validation reporting and dashboards
+- Integration with external quality tools (SonarQube, CodeClimate)
+- Advanced customization options for command generation
+- Machine learning-based quality assessment improvements
+- Cross-project template sharing and collaboration features
+
+## Updates During Session
+### Comprehensive README Overhaul
+- Added complete Validation System section documenting quality assurance framework
+- Created Custom Command Generation section with research-driven workflow examples
+- Added Project-Specific Testing section explaining auto-generated test capabilities
+- Enhanced Architecture section with new agent categories and validator documentation
+- Expanded Development section with validation loops and template system explanation
+- Updated all usage examples to demonstrate new features and capabilities
+- Comprehensive project structure updates reflecting all new components
+
+### Quality Assurance Integration
+- Integrated validation checkpoints throughout all documented workflows
+- Added quality metrics and success criteria documentation
+- Enhanced error handling and feedback mechanisms in workflow descriptions
+- Template system documentation for contributor consistency
+- Development best practices updated with validation-driven approach
+
+This represents the most comprehensive single-day enhancement in Claudio's development history, establishing it as a complete development ecosystem rather than just an analysis tool.

--- a/promptlog.md
+++ b/promptlog.md
@@ -381,10 +381,100 @@ the script should also check if claude is installed, and assumes the ci run or l
 
 /claudio:research software design https://12factor.net/
 
+# discovery issues 
+
+review the /claudio:claudio command, users are reporting that it is anaylyzing itself and not their projects
+
+ /claudio:claudio /path/to/project IMPORTANT: ignore the claudio
+directory its not part of the project, it is a tool to enhance the project, you don't need to discuss
+this just run the workflow on the target project and install the commands, use the validation agent to
+ensure the full workflow has run and the validation agent was successful.
+
+the upgrade process does need to use the `claudio` directory and the `.claudio` directory to update the `.claudio` directory the   │
+│   discovery process should only review the `.claudio` directory to see if there is an existing install and use it, the discovery     │
+│   process should never use the `claudio` directory, as it is analyzing the target project not itself.
+
+# validation loop not starting
+
+users are also reporting the install coordinator is not calling the install validator when complete this should always be the installs last task
+
+similarlly we want the claudio:claudio command coordinator to run its validation sub agent also
+
+the the primary workflows are :
+/claudio:claudio /path/to/project - run the workflow and validate
+/claudio:install /path/to/project - run the workflow validate, install the commands and sub agents validate
+/claudio:install commands - run the minimum discovery to create the localized commands then validate, then create the commands and subagents based on the discovery and validate
+
+
+1. /claudio:claudio /path/to/project → run workflow → validate completion
+2. /claudio:install /path/to/project → run workflow → validate workflow  → install → validate installation
+3. /claudio:install commands → discovery → validate discovery docs → install commands only → validate installation
+
+install commands, should always inlcude their required sub agents, and required extented contect documents in .claude/claudio/prompts
+
+review each validation subagent, ensure they have explict success criteria and report what is missing
+
+# test commands
+
+/claudio:generate-test-commands - creates custom commands with their subagents and extended context in the users target project as /claudio:test and /claudio:test-g
+
+each command, sub agent, and extenxted context, is generated using the context from the project discovery documents
+
+/claudio:test - by default runs the users test suite, and provides a summary, if given a --fix flag it makes a plan to address the issues
+
+/claudio:test-g - is a special agent that requires gemini-cli and gemini access, this command gives explict commands to gemini-cli through a bash tool use `gemini -y -p " {user input} + an explict prompt telling gemini it is in a read only mode, and is able to execute the projects test suite, use playwigh or other mcps where releveant and it ONLY responds in prompts to the claude sub agent that called it, it needs to provide a prompt of the issues found and a task list to address them ONLY, the claude sub agent will review the outputs by default and if the --fix flag is set attempt to fix them.
+
+the generated test comamnds /claudio:test, /claudio:test-g 
+are included in the 
+/claudio:install /path/to/project
+/claudio:upgrade /path/to/project
+/claudio:install commands /path/to/project
+/claudo:claudio /path/to/project
+
+the /claudio:generate-test-commands command is used to generate the /claudo:test and /claudio:test-g commands that get installed 
+upgraded or added to a project. the generate-test-commands command will not be installed upgrade or added to a users .claude directory ensure the validator and other subagents know this
+
+the the /claudio:generate-test-commmands will be run, during a /claudio:install, /claudio:install commands, /claudio:claudio, and /claudio:update
+
+# new command generator
+
+create /claudio:new-command  - the new command generator expects a user to provide a name and a purpose, and either a research document or a URL example 
+
+/claudio:new-command mycommand "does the thing I want" https://mything.information , or mything_readme.md 
+
+if a URL is provided, the sub agent uses the /claudio:research command to generate the extended context files for the command
+
+all new commands will follow our command structure of command, sub agent, extended context.
+we can use this as a pattern, and includes validation
+
+if the command needs to be added to the claudio workflow, they can add the --claudio "where it goes in the workflow" to their command like :
+
+/claudio:new-command mycommand "does the thing I want" https://mything.information , or mything_readme.md --claudio "add to after the discovery workflow"
+
+if the --claudio flag is not provided it is a user command and not part of the claudio workflow
+
+#  update docs
+
+review the current readme, the usage and commands have changed, update the read me with the new patterns and features add a development section if not already present that makes reference to the test folder and its patterns 
+
+# update change log
+
+diff our branch with main, and create a new change log in changelog/ with todays date
+
 #
 # todo:
 #
 
+# model diet
+
+use hakiu where possible for subagent work
+use opus where needed for research command
+allow research command to think and deep think
+
+prune sub agent context, rely on extended context files more, and sub section them into
+general
+troubleshooting
+specific-topics
 
 
 # claudini command

--- a/test/README.md
+++ b/test/README.md
@@ -63,9 +63,9 @@ This directory contains example projects specifically generated to test the comp
    - `ANTHROPIC_API_KEY` environment variable (recommended for CI)
    - Authenticated Claude CLI session (`claude auth`)
 
-3. **Permissions Flag**: All CI tests use the `--dangerously-skip-permissions` flag to avoid permission checks that can interfere with automated testing environments.
+3. **Permissions Flag**: All CI tests use the `--dangerously-skip-permissions --allow-dangerously-skip-permissions` dual-flag pattern. `--dangerously-skip-permissions` skips permission checks; `--allow-dangerously-skip-permissions` suppresses the interactive confirmation dialog that blocks non-TTY environments.
 
-**Command Format**: `claude -p "/claudio:command" --dangerously-skip-permissions`
+**Command Format**: `claude -p "/claudio:command" --dangerously-skip-permissions --allow-dangerously-skip-permissions`
 
 ### Automated Test Sequence
 
@@ -111,7 +111,7 @@ echo "=================================="
 # Test 1: Commands-Only Installation
 echo "📦 Test 1: Commands-Only Installation"
 cd test/install-commands
-claude -p "/claudio:install commands" --dangerously-skip-permissions
+claude -p "/claudio:install commands" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -d ".claude/commands" ] && [ -d ".claude/agents" ]; then
     echo "✅ Commands-only installation successful"
 else
@@ -123,7 +123,7 @@ cd ../..
 # Test 2: Simple Discovery (README-only project)
 echo "🔍 Test 2: Simple Discovery Analysis"
 cd test/discovery-readme
-claude -p "/claudio:discovery" --dangerously-skip-permissions
+claude -p "/claudio:discovery" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -f "discovery/reports/fittracker_discovery.md" ]; then
     echo "✅ Simple discovery analysis successful"
 else
@@ -135,7 +135,7 @@ cd ../..
 # Test 3: Complex Discovery (Code project)
 echo "🔍 Test 3: Complex Discovery Analysis"
 cd test/discovery-code
-claude -p "/claudio:discovery" --dangerously-skip-permissions
+claude -p "/claudio:discovery" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -f "discovery/reports/weather_api_discovery.md" ]; then
     echo "✅ Complex discovery analysis successful"
 else
@@ -147,7 +147,7 @@ cd ../..
 # Test 4: System Upgrade
 echo "⬆️  Test 4: System Upgrade"
 cd test/upgrade
-claude -p "/claudio:upgrade" --dangerously-skip-permissions
+claude -p "/claudio:upgrade" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -f ".claude/upgrade_changelog_$(date +%Y%m%d).md" ]; then
     echo "✅ System upgrade successful"
 else
@@ -159,7 +159,7 @@ cd ../..
 # Test 5: Full System Installation (Most comprehensive)
 echo "🏗️  Test 5: Full System Installation"
 cd test/install
-claude -p "/claudio:install" --dangerously-skip-permissions
+claude -p "/claudio:install" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -f ".claudio/summary.md" ] && [ -f ".claudio/discovery.md" ] && [ -f ".claudio/prd.md" ]; then
     echo "✅ Full system installation successful"
 else
@@ -179,19 +179,19 @@ For manual testing or debugging specific workflows:
 
 ```bash
 # Test commands-only installation
-cd test/install-commands && claude -p "/claudio:install commands" --dangerously-skip-permissions
+cd test/install-commands && claude -p "/claudio:install commands" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 
 # Test simple discovery
-cd test/discovery-readme && claude -p "/claudio:discovery" --dangerously-skip-permissions
+cd test/discovery-readme && claude -p "/claudio:discovery" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 
 # Test complex discovery with code analysis
-cd test/discovery-code && claude -p "/claudio:discovery" --dangerously-skip-permissions
+cd test/discovery-code && claude -p "/claudio:discovery" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 
 # Test system upgrade workflow
-cd test/upgrade && claude -p "/claudio:upgrade" --dangerously-skip-permissions
+cd test/upgrade && claude -p "/claudio:upgrade" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 
 # Test full system installation
-cd test/install && claude -p "/claudio:install" --dangerously-skip-permissions
+cd test/install && claude -p "/claudio:install" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 ```
 
 ### Validation Checks
@@ -232,7 +232,7 @@ Each test should validate specific outputs:
 ./test/claudio-ci-test.sh
 
 # Test specific workflow (with permissions flag for CI compatibility)
-cd test/discovery-code && claude -p "/claudio:discovery" --dangerously-skip-permissions
+cd test/discovery-code && claude -p "/claudio:discovery" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 ```
 
 ### CI/CD Integration

--- a/test/claudio-ci-test.sh
+++ b/test/claudio-ci-test.sh
@@ -42,7 +42,7 @@ echo "=================================="
 # Test 1: Commands-Only Installation
 echo "📦 Test 1: Commands-Only Installation"
 cd test/install-commands
-claude -p "/claudio:install commands" --dangerously-skip-permissions
+claude -p "/claudio:install commands" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -d ".claude/commands" ] && [ -d ".claude/agents" ]; then
     echo "✅ Commands-only installation successful"
 else
@@ -54,7 +54,7 @@ cd ../..
 # Test 2: Simple Discovery (README-only project)
 echo "🔍 Test 2: Simple Discovery Analysis"
 cd test/discovery-readme
-claude -p "/claudio:discovery" --dangerously-skip-permissions
+claude -p "/claudio:discovery" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -f "discovery/reports/fittracker_discovery.md" ]; then
     echo "✅ Simple discovery analysis successful"
 else
@@ -66,7 +66,7 @@ cd ../..
 # Test 3: Complex Discovery (Code project)
 echo "🔍 Test 3: Complex Discovery Analysis"
 cd test/discovery-code
-claude -p "/claudio:discovery" --dangerously-skip-permissions
+claude -p "/claudio:discovery" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -f "discovery/reports/weather_api_discovery.md" ]; then
     echo "✅ Complex discovery analysis successful"
 else
@@ -78,7 +78,7 @@ cd ../..
 # Test 4: System Upgrade
 echo "⬆️  Test 4: System Upgrade"
 cd test/upgrade
-claude -p "/claudio:upgrade" --dangerously-skip-permissions
+claude -p "/claudio:upgrade" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -f ".claude/upgrade_changelog_$(date +%Y%m%d).md" ]; then
     echo "✅ System upgrade successful"
 else
@@ -90,7 +90,7 @@ cd ../..
 # Test 5: Full System Installation (Most comprehensive)
 echo "🏗️  Test 5: Full System Installation"
 cd test/install
-claude -p "/claudio:install" --dangerously-skip-permissions
+claude -p "/claudio:install" --dangerously-skip-permissions --allow-dangerously-skip-permissions
 if [ -f ".claudio/summary.md" ] && [ -f ".claudio/discovery.md" ] && [ -f ".claudio/prd.md" ]; then
     echo "✅ Full system installation successful"
 else


### PR DESCRIPTION
## Summary

- Add `--allow-dangerously-skip-permissions` alongside existing `--dangerously-skip-permissions` at all 5 claude invocation sites in `test/claudio-ci-test.sh`
- Update `test/README.md` to document the dual-flag pattern and why it is required for non-TTY environments

## Why

The single `--dangerously-skip-permissions` flag triggers an interactive confirmation dialog (\"Yes, I accept\" / \"No, exit\"). When running in CI or a tmux session without a TTY-bound operator, the dialog blocks indefinitely. The dual-flag pattern (`--dangerously-skip-permissions --allow-dangerously-skip-permissions`) declares explicit authorization, suppressing the dialog.

Verified empirically by operator 2026-05-07: dual-flag combo runs cleanly without the warning.

## Files changed

- `test/claudio-ci-test.sh:45,57,69,81,93` — 5 active claude invocations, all updated to dual-flag
- `test/README.md` — Updated flag description and all example command lines

## Test plan

- [x] All 5 active claude invocations updated
- [x] README updated to teach the correct dual-flag pattern
- [ ] Post-merge: CI test run succeeds without interactive dialog blocking